### PR TITLE
feat: temporarily remove community partners section #136

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -167,7 +167,7 @@ const ogImageUrl = absoluteUrl(DEFAULT_OG_IMAGE_PATH, Astro);
     <HighlightReel content={eventHighlightsContent} />
     <Ticker content={tickerContent} />
     <OurPartners />
-    <CommunityPartners />
+    <!-- <CommunityPartners /> -->
     <PastSponsors content={pastSponsorsContent} />
     <LocalCharitySection />
 


### PR DESCRIPTION
The community partners section has been temporarily commented out as requested. We can easily bring it back once the partners are officially confirmed.
@vincent6767  Check!!!