### PR TITLE
feat: update press release for Toronto #144

### DIFF
--- a/src/pages/press-release.astro
+++ b/src/pages/press-release.astro
@@ -7,472 +7,472 @@ import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 import SeoSocial from '../components/SeoSocial.astro';
 import { absoluteUrl, DEFAULT_OG_IMAGE_PATH, getCanonical } from '../lib/seo';
 
-const pageTitle = 'Press Release — Cloud Summit Vancouver 2026 | Cloud Summit';
+const pageTitle = 'Press Release — Cloud Summit Toronto 2026 | Cloud Summit';
 const pageDescription =
-	'Cloud Summit Vancouver 2026 returns to Science World this May: community-run nonprofit multi-cloud conference for professionals, leaders, and local tech communities.';
+    'Cloud Summit Toronto 2026 comes to Northeastern University this August: community-run nonprofit multi-cloud conference for professionals, leaders, and local tech communities.';
 const canonicalUrl = getCanonical(Astro);
 const ogImageUrl = absoluteUrl(DEFAULT_OG_IMAGE_PATH, Astro);
 ---
 
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="canonical" href={canonicalUrl} />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<meta name="description" content={pageDescription} />
-		<SeoSocial
-			title={pageTitle}
-			description={pageDescription}
-			canonicalUrl={canonicalUrl}
-			ogImageUrl={ogImageUrl}
-		/>
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-		<link
-			href="https://fonts.googleapis.com/css2?family=Squada+One&family=Noto+Sans:wght@400;500;600;700&family=Doto:wght@100..900&display=swap"
-			rel="stylesheet"
-		/>
-		<title>{pageTitle}</title>
-		<GoogleAnalytics />
-	</head>
-	<body>
-		<Navigation content={navigationContent} />
+    <head>
+        <meta charset="utf-8" />
+        <link rel="canonical" href={canonicalUrl} />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        <meta name="viewport" content="width=device-width" />
+        <meta name="generator" content={Astro.generator} />
+        <meta name="description" content={pageDescription} />
+        <SeoSocial
+            title={pageTitle}
+            description={pageDescription}
+            canonicalUrl={canonicalUrl}
+            ogImageUrl={ogImageUrl}
+        />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Squada+One&family=Noto+Sans:wght@400;500;600;700&family=Doto:wght@100..900&display=swap"
+            rel="stylesheet"
+        />
+        <title>{pageTitle}</title>
+        <GoogleAnalytics />
+    </head>
+    <body>
+        <Navigation content={navigationContent} />
 
-		<main class="press-page">
-			<section class="press-hero">
-				<div class="pulsing-squares">
-					<div class="square" style="left: 10%; top: 15%;"></div>
-					<div class="square" style="left: 25%; top: 25%;"></div>
-					<div class="square" style="left: 40%; top: 18%;"></div>
-					<div class="square" style="left: 55%; top: 30%;"></div>
-					<div class="square" style="left: 70%; top: 22%;"></div>
-					<div class="square" style="left: 85%; top: 35%;"></div>
-					<div class="square" style="left: 15%; top: 45%;"></div>
-					<div class="square" style="left: 35%; top: 50%;"></div>
-					<div class="square" style="left: 50%; top: 13%;"></div>
-					<div class="square" style="left: 65%; top: 55%;"></div>
-					<div class="square" style="left: 80%; top: 48%;"></div>
-					<div class="square" style="left: 20%; top: 60%;"></div>
-					<div class="square" style="left: 45%; top: 65%;"></div>
-					<div class="square" style="left: 75%; top: 70%;"></div>
-					<div class="square" style="left: 30%; top: 75%;"></div>
-				</div>
-				<div class="hero-container">
-					<p class="press-kicker">FOR IMMEDIATE RELEASE</p>
-					<h1 class="hero-title">
-						Cloud Summit Vancouver 2026 Returns to Science World This May
-					</h1>
-					<p class="hero-subtitle">
-						Community-run nonprofit cloud conference to bring together hundreds of professionals, industry
-						leaders, and local tech communities in Vancouver
-					</p>
-				</div>
-			</section>
+        <main class="press-page">
+            <section class="press-hero">
+                <div class="pulsing-squares">
+                    <div class="square" style="left: 10%; top: 15%;"></div>
+                    <div class="square" style="left: 25%; top: 25%;"></div>
+                    <div class="square" style="left: 40%; top: 18%;"></div>
+                    <div class="square" style="left: 55%; top: 30%;"></div>
+                    <div class="square" style="left: 70%; top: 22%;"></div>
+                    <div class="square" style="left: 85%; top: 35%;"></div>
+                    <div class="square" style="left: 15%; top: 45%;"></div>
+                    <div class="square" style="left: 35%; top: 50%;"></div>
+                    <div class="square" style="left: 50%; top: 13%;"></div>
+                    <div class="square" style="left: 65%; top: 55%;"></div>
+                    <div class="square" style="left: 80%; top: 48%;"></div>
+                    <div class="square" style="left: 20%; top: 60%;"></div>
+                    <div class="square" style="left: 45%; top: 65%;"></div>
+                    <div class="square" style="left: 75%; top: 70%;"></div>
+                    <div class="square" style="left: 30%; top: 75%;"></div>
+                </div>
+                <div class="hero-container">
+                    <p class="press-kicker">FOR IMMEDIATE RELEASE</p>
+                    <h1 class="hero-title">
+                        Cloud Summit Toronto 2026 Comes to Northeastern University This August
+                    </h1>
+                    <p class="hero-subtitle">
+                        Community-run nonprofit cloud conference to bring together hundreds of professionals, industry
+                        leaders, and local tech communities in Toronto
+                    </p>
+                </div>
+            </section>
 
-			<section class="press-content" aria-label="Press release body">
-				<div class="press-container">
-					<p>
-						<strong>
-							VANCOUVER, BC, April 1, 2026 — Cloud Summit Vancouver 2026 will take place on Friday, May 1, 2026
-						</strong>{' '}
-						at <strong>Science World</strong> in Vancouver, bringing together cloud professionals, technology leaders,
-						sponsors, startups, and community groups for a major day of learning, networking, and innovation. Official
-						event information says the conference will welcome{' '}
-						<strong>hundreds of cloud professionals and decision-makers</strong> from across the cloud ecosystem.{' '}
-						<a
-							href="https://cloudsummit.ca/"
-							class="press-cite"
-							target="_blank"
-							rel="noopener noreferrer"
-							>(Cloud Summit)</a>
-					</p>
-					<p>
-						Organized under the <strong>Canadian Public Cloud Association (CPCA)</strong>, Cloud Summit is part of
-						a broader nonprofit mission to educate the local tech community, bring people together, and support the
-						community through charitable giving. Cloud Summit’s official materials say the event has already helped
-						raise <strong>more than $10,000 for charity to date</strong>.{' '}
-						<a
-							href="https://canadiancloud.org/"
-							class="press-cite"
-							target="_blank"
-							rel="noopener noreferrer"
-							>(Canadian Cloud)</a>
-					</p>
-					<p>
-						Cloud Summit Vancouver 2026 will feature speakers, workshops, networking, sponsor activations, and
-						community experiences spanning the modern cloud landscape. According to the event website, Cloud Summit
-						brings together professionals from{' '}
-						<strong>AWS, Azure, Google Cloud, Oracle and IBM Cloud</strong> ecosystems, along with local communities
-						and technology companies shaping the future of cloud computing in Canada.{' '}
-						<a
-							href="https://cloudsummit.ca/"
-							class="press-cite"
-							target="_blank"
-							rel="noopener noreferrer"
-							>(Cloud Summit)</a>
-					</p>
-					<blockquote class="press-quote">
-						<p>
-							“Cloud Summit is about bringing the local tech community together in a way that feels accessible,
-							high-value, and genuinely community-driven,” said{' '}
-							<strong>Jhan Silva, Sr DevOps Engineer and Cloud Summit Sponsorship Committee Lead</strong>. “We’re
-							creating a
-							space where builders, leaders, students, startups, and enterprise teams can connect, learn from each
-							other, and help strengthen the local cloud ecosystem.”
-						</p>
-					</blockquote>
-					<p>
-						Event highlights promoted by organizers include expert-led presentations, hands-on workshops, networking
-						opportunities, sponsor and community showcase areas, and high-energy live cloud build competitions. The
-						official site also lists past event metrics including{' '}
-						<strong>800+ in-person attendees, 19 speakers, and 12+ sponsors and communities</strong>.{' '}
-						<a
-							href="https://cloudsummit.ca/"
-							class="press-cite"
-							target="_blank"
-							rel="noopener noreferrer"
-							>(Cloud Summit)</a>
-					</p>
-					<p>
-						Cloud Summit has grown into one of Canada’s most visible community-led cloud gatherings, with events now
-						held in both Vancouver and Toronto. Vancouver’s 2026 edition will once again take place at the iconic
-						Science World venue, reinforcing the event’s focus on combining technical depth, community energy, and
-						local impact.{' '}
-						<a
-							href="https://cloudsummit.ca/"
-							class="press-cite"
-							target="_blank"
-							rel="noopener noreferrer"
-							>(Cloud Summit)</a>
-					</p>
-					<p>
-						Attendees, media, sponsors, speakers, and community partners can learn more through the official Cloud
-						Summit and CPCA channels. Contact information published by CPCA lists{' '}
-						<strong>
-							<a href="mailto:connect@canadiancloud.org" class="press-inline-email">connect@canadiancloud.org</a>
-						</strong>{' '}
-						for inquiries.{' '}
-						<strong>
-							<a
-								href="https://canadiancloud.org/"
-								class="press-cite press-cite--bold"
-								target="_blank"
-								rel="noopener noreferrer"
-								>(Canadian Cloud)</a>
-						</strong>
-					</p>
+            <section class="press-content" aria-label="Press release body">
+                <div class="press-container">
+                    <p>
+                        <strong>
+                            TORONTO, ON, June 2026 — Cloud Summit Toronto 2026 will take place on Saturday, August 29, 2026
+                        </strong>{' '}
+                        at <strong>Northeastern University</strong> in Toronto, bringing together cloud professionals, technology leaders,
+                        sponsors, startups, and community groups for a major day of learning, networking, and innovation. The
+                        conference is expected to welcome{' '}
+                        <strong>hundreds of cloud professionals and decision-makers</strong> from across the cloud ecosystem.{' '}
+                        <a
+                            href="https://cloudsummit.ca/"
+                            class="press-cite"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >(Cloud Summit)</a>
+                    </p>
+                    <p>
+                        Organized under the <strong>Canadian Public Cloud Association (CPCA)</strong>, Cloud Summit is part of
+                        a broader nonprofit mission to educate the local tech community, bring people together, and support the
+                        community through charitable giving. Cloud Summit has helped
+                        raise <strong>more than $10,000 for charity to date</strong> through its community-driven initiatives.{' '}
+                        <a
+                            href="https://canadiancloud.org/"
+                            class="press-cite"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >(Canadian Cloud)</a>
+                    </p>
+                    <p>
+                        Cloud Summit Toronto 2026 will feature speakers, workshops, networking, sponsor activations, and
+                        community experiences spanning the modern cloud landscape. The event
+                        brings together professionals from{' '}
+                        <strong>AWS, Azure, Google Cloud, Oracle, and IBM Cloud</strong> ecosystems, along with local communities
+                        and technology companies shaping the future of cloud computing in Canada.{' '}
+                        <a
+                            href="https://cloudsummit.ca/"
+                            class="press-cite"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >(Cloud Summit)</a>
+                    </p>
+                    <blockquote class="press-quote">
+                        <p>
+                            “Cloud Summit is about bringing the local tech community together in a way that feels accessible,
+                            high-value, and genuinely community-driven,” said{' '}
+                            <strong>Jhan Silva, Sr DevOps Engineer and Cloud Summit Sponsorship Committee Lead</strong>. “We’re
+                            creating a
+                            space where builders, leaders, students, startups, and enterprise teams can connect, learn from each
+                            other, and help strengthen the local cloud ecosystem.”
+                        </p>
+                    </blockquote>
+                    <p>
+                        Event highlights include expert-led presentations, hands-on workshops, networking
+                        opportunities, sponsor and community showcase areas, and high-energy live cloud build competitions. Previous
+                        Cloud Summit events have welcomed more than{' '}
+                        <strong>800 in-person attendees and featured dozens of speakers, sponsors, and community partners</strong> from across Canada's cloud ecosystem.{' '}
+                        <a
+                            href="https://cloudsummit.ca/"
+                            class="press-cite"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >(Cloud Summit)</a>
+                    </p>
+                    <p>
+                        Cloud Summit has grown into one of Canada’s most recognized community-led cloud gatherings, with events now
+                        held in both Vancouver and Toronto. The Toronto 2026 edition at Northeastern University will continue the
+                        event's tradition of combining technical depth, community engagement, and meaningful local impact.{' '}
+						
+                        <a
+                            href="https://cloudsummit.ca/"
+                            class="press-cite"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >(Cloud Summit)</a>
+                    </p>
+                    <p>
+                        Attendees, media, sponsors, speakers, and community partners can learn more through the official Cloud
+                        Summit and CPCA channels. For inquiries, please contact{' '}
+                        <strong>
+                            <a href="mailto:connect@canadiancloud.org" class="press-inline-email">connect@canadiancloud.org</a>
+                        </strong>{' '}
+						 
+                        <strong>
+                            <a
+                                href="https://canadiancloud.org/"
+                                class="press-cite press-cite--bold"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                >(Canadian Cloud)</a>
+                        </strong>
+                    </p>
 
-					<h2 class="press-section-title">About Cloud Summit</h2>
-					<p>
-						Cloud Summit is a Canadian multi-cloud conference focused on connecting cloud professionals, industry
-						leaders, technology companies, and local communities through presentations, workshops, networking, and
-						hands-on learning. The event is organized as part of the Canadian Public Cloud Association’s nonprofit
-						mission to educate the local tech community, bring people together, and give back through charity.{' '}
-						<a
-							href="https://cloudsummit.ca/"
-							class="press-cite"
-							target="_blank"
-							rel="noopener noreferrer"
-							>(Cloud Summit)</a>
-					</p>
+                    <h2 class="press-section-title">About Cloud Summit</h2>
+                    <p>
+                        Cloud Summit is a Canadian multi-cloud conference focused on connecting cloud professionals, industry
+                        leaders, technology companies, and local communities through presentations, workshops, networking, and
+                        hands-on learning. The event is organized as part of the Canadian Public Cloud Association’s nonprofit
+                        mission to educate the local tech community, bring people together, and give back through charity.{' '}
+                        <a
+                            href="https://cloudsummit.ca/"
+                            class="press-cite"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >(Cloud Summit)</a>
+                    </p>
 
-					<h2 class="press-section-title">Media Contact</h2>
-					<p class="press-contact">
-						<strong>Matt Carolan</strong><br />
-						<strong>Operations Lead</strong><br />
-						<strong><a href="mailto:matt@cloudsummit.ca">matt@cloudsummit.ca</a></strong>
-					</p>
-				</div>
-			</section>
-		</main>
+                    <h2 class="press-section-title">Media Contact</h2>
+                    <p class="press-contact">
+                        <strong>Matt Carolan</strong><br />
+                        <strong>Operations Lead</strong><br />
+                        <strong><a href="mailto:matt@cloudsummit.ca">matt@cloudsummit.ca</a></strong>
+                    </p>
+                </div>
+            </section>
+        </main>
 
-		<Footer content={footerContent} />
-		<ScrollAnimations />
-	</body>
+        <Footer content={footerContent} />
+        <ScrollAnimations />
+    </body>
 </html>
 
 <style is:global>
-	* {
-		margin: 0;
-		padding: 0;
-		box-sizing: border-box;
-	}
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
 
-	html {
-		font-family:
-			'Noto Sans',
-			system-ui,
-			-apple-system,
-			BlinkMacSystemFont,
-			'Segoe UI',
-			Roboto,
-			Oxygen,
-			Ubuntu,
-			Cantarell,
-			sans-serif;
-		line-height: 1.6;
-		color: #1a1a1a;
-	}
+    html {
+        font-family:
+            'Noto Sans',
+            system-ui,
+            -apple-system,
+            BlinkMacSystemFont,
+            'Segoe UI',
+            Roboto,
+            Oxygen,
+            Ubuntu,
+            Cantarell,
+            sans-serif;
+        line-height: 1.6;
+        color: #1a1a1a;
+    }
 
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		font-family: 'Squada One', system-ui, sans-serif;
-		font-weight: 400;
-		letter-spacing: 0.02em;
-	}
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-family: 'Squada One', system-ui, sans-serif;
+        font-weight: 400;
+        letter-spacing: 0.02em;
+    }
 
-	body {
-		min-height: 100vh;
-		background: black;
-		color: white;
-	}
+    body {
+        min-height: 100vh;
+        background: black;
+        color: white;
+    }
 </style>
 
 <style>
-	.press-page {
-		background: black;
-		color: white;
-	}
+    .press-page {
+        background: black;
+        color: white;
+    }
 
-	.press-page strong {
-		font-weight: 700;
-		color: #fff;
-	}
+    .press-page strong {
+        font-weight: 700;
+        color: #fff;
+    }
 
-	.press-hero {
-		padding: 6rem 1.5rem 2.5rem;
-		background: black;
-		position: relative;
-		overflow: hidden;
-	}
+    .press-hero {
+        padding: 6rem 1.5rem 2.5rem;
+        background: black;
+        position: relative;
+        overflow: hidden;
+    }
 
-	.pulsing-squares {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		pointer-events: none;
-		z-index: 0;
-	}
+    .pulsing-squares {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        z-index: 0;
+    }
 
-	.square {
-		position: absolute;
-		width: 15px;
-		height: 15px;
-		background: rgb(251, 113, 133);
-		animation: pulse 2s ease-in-out infinite;
-	}
+    .square {
+        position: absolute;
+        width: 15px;
+        height: 15px;
+        background: rgb(251, 113, 133);
+        animation: pulse 2s ease-in-out infinite;
+    }
 
-	.square:nth-child(1) {
-		animation-delay: 0s;
-		opacity: 0.4;
-	}
-	.square:nth-child(2) {
-		animation-delay: 0.3s;
-		opacity: 0.38;
-	}
-	.square:nth-child(3) {
-		animation-delay: 0.6s;
-		opacity: 0.4;
-	}
-	.square:nth-child(4) {
-		animation-delay: 0.9s;
-		opacity: 0.32;
-	}
-	.square:nth-child(5) {
-		animation-delay: 1.2s;
-		opacity: 0.38;
-	}
-	.square:nth-child(6) {
-		animation-delay: 1.5s;
-		opacity: 0.3;
-	}
-	.square:nth-child(7) {
-		animation-delay: 0.4s;
-		opacity: 0.28;
-	}
-	.square:nth-child(8) {
-		animation-delay: 0.8s;
-		opacity: 0.25;
-	}
-	.square:nth-child(9) {
-		animation-delay: 0.2s;
-		opacity: 0.45;
-	}
-	.square:nth-child(10) {
-		animation-delay: 1.1s;
-		opacity: 0.22;
-	}
-	.square:nth-child(11) {
-		animation-delay: 1.4s;
-		opacity: 0.25;
-	}
-	.square:nth-child(12) {
-		animation-delay: 0.5s;
-		opacity: 0.2;
-	}
-	.square:nth-child(13) {
-		animation-delay: 1s;
-		opacity: 0.18;
-	}
-	.square:nth-child(14) {
-		animation-delay: 1.3s;
-		opacity: 0.15;
-	}
-	.square:nth-child(15) {
-		animation-delay: 0.7s;
-		opacity: 0.18;
-	}
+    .square:nth-child(1) {
+        animation-delay: 0s;
+        opacity: 0.4;
+    }
+    .square:nth-child(2) {
+        animation-delay: 0.3s;
+        opacity: 0.38;
+    }
+    .square:nth-child(3) {
+        animation-delay: 0.6s;
+        opacity: 0.4;
+    }
+    .square:nth-child(4) {
+        animation-delay: 0.9s;
+        opacity: 0.32;
+    }
+    .square:nth-child(5) {
+        animation-delay: 1.2s;
+        opacity: 0.38;
+    }
+    .square:nth-child(6) {
+        animation-delay: 1.5s;
+        opacity: 0.3;
+    }
+    .square:nth-child(7) {
+        animation-delay: 0.4s;
+        opacity: 0.28;
+    }
+    .square:nth-child(8) {
+        animation-delay: 0.8s;
+        opacity: 0.25;
+    }
+    .square:nth-child(9) {
+        animation-delay: 0.2s;
+        opacity: 0.45;
+    }
+    .square:nth-child(10) {
+        animation-delay: 1.1s;
+        opacity: 0.22;
+    }
+    .square:nth-child(11) {
+        animation-delay: 1.4s;
+        opacity: 0.25;
+    }
+    .square:nth-child(12) {
+        animation-delay: 0.5s;
+        opacity: 0.2;
+    }
+    .square:nth-child(13) {
+        animation-delay: 1s;
+        opacity: 0.18;
+    }
+    .square:nth-child(14) {
+        animation-delay: 1.3s;
+        opacity: 0.15;
+    }
+    .square:nth-child(15) {
+        animation-delay: 0.7s;
+        opacity: 0.18;
+    }
 
-	@keyframes pulse {
-		0%,
-		100% {
-			transform: scale(1);
-		}
-		50% {
-			transform: scale(1.3);
-		}
-	}
+    @keyframes pulse {
+        0%,
+        100% {
+            transform: scale(1);
+        }
+        50% {
+            transform: scale(1.3);
+        }
+    }
 
-	.hero-container {
-		max-width: 900px;
-		margin: 0 auto;
-		text-align: center;
-		position: relative;
-		z-index: 1;
-	}
+    .hero-container {
+        max-width: 900px;
+        margin: 0 auto;
+        text-align: center;
+        position: relative;
+        z-index: 1;
+    }
 
-	.press-kicker {
-		font-size: 0.8125rem;
-		font-weight: 600;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: rgb(255, 193, 77);
-		margin: 0 0 1rem 0;
-	}
+    .press-kicker {
+        font-size: 0.8125rem;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgb(255, 193, 77);
+        margin: 0 0 1rem 0;
+    }
 
-	.hero-title {
-		font-family: 'Squada One', system-ui, sans-serif;
-		font-size: 2rem;
-		line-height: 1.15;
-		margin: 0 0 1rem 0;
-		color: rgb(251, 113, 133);
-	}
+    .hero-title {
+        font-family: 'Squada One', system-ui, sans-serif;
+        font-size: 2rem;
+        line-height: 1.15;
+        margin: 0 0 1rem 0;
+        color: rgb(251, 113, 133);
+    }
 
-	.hero-subtitle {
-		font-size: 1.125rem;
-		margin: 0;
-		line-height: 1.55;
-		opacity: 0.92;
-		font-weight: 400;
-	}
+    .hero-subtitle {
+        font-size: 1.125rem;
+        margin: 0;
+        line-height: 1.55;
+        opacity: 0.92;
+        font-weight: 400;
+    }
 
-	.press-content {
-		padding: 0 1.5rem 4rem;
-	}
+    .press-content {
+        padding: 0 1.5rem 4rem;
+    }
 
-	.press-container {
-		max-width: 42rem;
-		margin: 0 auto;
-	}
+    .press-container {
+        max-width: 42rem;
+        margin: 0 auto;
+    }
 
-	.press-container p {
-		margin: 0 0 1.25rem 0;
-		font-size: 1rem;
-		line-height: 1.7;
-		opacity: 0.94;
-	}
+    .press-container p {
+        margin: 0 0 1.25rem 0;
+        font-size: 1rem;
+        line-height: 1.7;
+        opacity: 0.94;
+    }
 
-	.press-container a {
-		color: rgb(113, 198, 251);
-		text-decoration: none;
-	}
+    .press-container a {
+        color: rgb(113, 198, 251);
+        text-decoration: none;
+    }
 
-	.press-container a:hover {
-		text-decoration: underline;
-	}
+    .press-container a:hover {
+        text-decoration: underline;
+    }
 
-	.press-cite {
-		font-size: 0.875rem;
-		opacity: 0.65;
-		white-space: nowrap;
-	}
+    .press-cite {
+        font-size: 0.875rem;
+        opacity: 0.65;
+        white-space: nowrap;
+    }
 
-	.press-container a.press-cite {
-		text-decoration: underline;
-		text-underline-offset: 2px;
-	}
+    .press-container a.press-cite {
+        text-decoration: underline;
+        text-underline-offset: 2px;
+    }
 
-	strong .press-cite--bold {
-		font-weight: 700;
-		opacity: 0.92;
-	}
+    strong .press-cite--bold {
+        font-weight: 700;
+        opacity: 0.92;
+    }
 
-	.press-inline-email {
-		font-weight: inherit;
-		color: rgb(113, 198, 251);
-	}
+    .press-inline-email {
+        font-weight: inherit;
+        color: rgb(113, 198, 251);
+    }
 
-	.press-quote {
-		margin: 1.75rem 0;
-		padding: 1.25rem 1.25rem 1.25rem 1.5rem;
-		border-left: 4px solid rgba(61, 120, 171, 0.75);
-		background: rgba(61, 120, 171, 0.12);
-		border-radius: 0 0.5rem 0.5rem 0;
-	}
+    .press-quote {
+        margin: 1.75rem 0;
+        padding: 1.25rem 1.25rem 1.25rem 1.5rem;
+        border-left: 4px solid rgba(61, 120, 171, 0.75);
+        background: rgba(61, 120, 171, 0.12);
+        border-radius: 0 0.5rem 0.5rem 0;
+    }
 
-	.press-quote p {
-		margin: 0;
-		font-style: italic;
-		opacity: 0.96;
-	}
+    .press-quote p {
+        margin: 0;
+        font-style: italic;
+        opacity: 0.96;
+    }
 
-	.press-section-title {
-		font-family: 'Squada One', system-ui, sans-serif;
-		font-size: 1.75rem;
-		margin: 2.25rem 0 0.75rem 0;
-		color: rgb(255, 193, 77);
-		font-weight: 400;
-	}
+    .press-section-title {
+        font-family: 'Squada One', system-ui, sans-serif;
+        font-size: 1.75rem;
+        margin: 2.25rem 0 0.75rem 0;
+        color: rgb(255, 193, 77);
+        font-weight: 400;
+    }
 
-	.press-section-title:first-of-type {
-		margin-top: 2.5rem;
-	}
+    .press-section-title:first-of-type {
+        margin-top: 2.5rem;
+    }
 
-	.press-contact {
-		line-height: 1.65;
-	}
+    .press-contact {
+        line-height: 1.65;
+    }
 
-	.press-contact strong a {
-		font-weight: 700;
-	}
+    .press-contact strong a {
+        font-weight: 700;
+    }
 
-	@media (min-width: 769px) {
-		.press-hero {
-			padding: 6rem 2rem 3rem;
-		}
+    @media (min-width: 769px) {
+        .press-hero {
+            padding: 6rem 2rem 3rem;
+        }
 
-		.hero-title {
-			font-size: 2.75rem;
-		}
+        .hero-title {
+            font-size: 2.75rem;
+        }
 
-		.hero-subtitle {
-			font-size: 1.25rem;
-		}
+        .hero-subtitle {
+            font-size: 1.25rem;
+        }
 
-		.press-content {
-			padding: 0 2rem 5rem;
-		}
+        .press-content {
+            padding: 0 2rem 5rem;
+        }
 
-		.press-container p {
-			font-size: 1.0625rem;
-		}
-	}
+        .press-container p {
+            font-size: 1.0625rem;
+        }
+    }
 </style>


### PR DESCRIPTION
This PR updates the full Press Release page content from Vancouver to Toronto 2026 as requested. All existing styles and layout structures remain fully intact.

@vincent6767 Check!!!