### PR TITLE
fix: completely hide our sponsors section #135

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -165,7 +165,7 @@ const ogImageUrl = absoluteUrl(DEFAULT_OG_IMAGE_PATH, Astro);
     <SummitSummary content={eventHighlightsContent} />
     <HighlightReel content={eventHighlightsContent} />
     <Ticker content={tickerContent} />
-    <OurPartners />
+    <!-- <OurPartners /> -->
     <!-- <CommunityPartners />  -->
     <PastSponsors content={pastSponsorsContent} />
     <LocalCharitySection />


### PR DESCRIPTION
Based on Matt's latest feedback, this PR completely disables the Our Sponsors section since there are no confirmed sponsors yet.