### PR TITLE
test: add unit tests for newsletter buttons and verify target blank #138

### DIFF
--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -19,7 +19,7 @@ const { content } = Astro.props;
 			{content.heading}
 		</h2>
 		<p class="newsletter-description">{content.description}</p>
-		<a href={content.ctaHref} class="newsletter-button">
+		<a target="_blank" rel="noopener noreferrer" href={content.ctaHref} class="newsletter-button">
 			{content.ctaText}
 		</a>
 	</div>

--- a/src/components/SubscribetoNewsletterButtom.test.ts
+++ b/src/components/SubscribetoNewsletterButtom.test.ts
@@ -7,14 +7,14 @@ const mockCity = "vancouver";
 const footerContent = getFooterContent(mockCity);
 
 describe("Newsletter Target Buttons Unit Tests (#138)", () => {
-  // ۱. تست صحت ساختار داده‌ها (Content Data)
+  // 1. Testing data structure integrity (Content Data)
   it("should verify the content structure for Newsletter is correctly configured", () => {
     expect(newsletterContent).toBeDefined();
     expect(newsletterContent.ctaText).toBe("Subscribe to Newsletter"); // اصلاح شده بر اساس دیتای واقعی فایل شما
     expect(newsletterContent.ctaHref).toBe("https://tally.so/r/mR6RBl");
   });
 
-  // ۲. تست وجود هاردکد target="_blank" درون کامپوننت کاملا به صورت خودکار
+  // 2. Testing the presence of hardcoded target="_blank" within the component
   it("should ensure the HTML link inside Newsletter.astro has target='_blank' and safe rel attributes", () => {
     // خواندن فایل کامپوننت از روی دیسک
     const componentPath = path.resolve(
@@ -23,11 +23,11 @@ describe("Newsletter Target Buttons Unit Tests (#138)", () => {
     );
     const componentContent = fs.readFileSync(componentPath, "utf8");
 
-    // بررسی وجود دقیق اتربیوت‌ها روی تگ a در کامپوننت
+    // Checking the exact presence of attributes on the <a> tag in the component
     expect(componentContent).toContain('target="_blank"');
     expect(componentContent).toContain('rel="noopener noreferrer"');
 
-    // بررسی دقیق‌تر ساختار خط تگ a
+    // Checking the exact structure of the <a> tag in the component
     const hasCorrectAnchorTag = componentContent.includes(
       '<a target="_blank" rel="noopener noreferrer" href={content.ctaHref} class="newsletter-button">',
     );

--- a/src/components/SubscribetoNewsletterButtom.test.ts
+++ b/src/components/SubscribetoNewsletterButtom.test.ts
@@ -16,7 +16,7 @@ describe("Newsletter Target Buttons Unit Tests (#138)", () => {
 
   // 2. Testing the presence of hardcoded target="_blank" within the component
   it("should ensure the HTML link inside Newsletter.astro has target='_blank' and safe rel attributes", () => {
-    // خواندن فایل کامپوننت از روی دیسک
+    // Reading the component file from disk
     const componentPath = path.resolve(
       process.cwd(),
       "src/components/Newsletter.astro",

--- a/src/components/SubscribetoNewsletterButtom.test.ts
+++ b/src/components/SubscribetoNewsletterButtom.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getFooterContent, newsletterContent } from "../lib/content";
+import fs from "fs";
+import path from "path";
+
+const mockCity = "vancouver";
+const footerContent = getFooterContent(mockCity);
+
+describe("Newsletter Target Buttons Unit Tests (#138)", () => {
+  // ۱. تست صحت ساختار داده‌ها (Content Data)
+  it("should verify the content structure for Newsletter is correctly configured", () => {
+    expect(newsletterContent).toBeDefined();
+    expect(newsletterContent.ctaText).toBe("Subscribe to Newsletter"); // اصلاح شده بر اساس دیتای واقعی فایل شما
+    expect(newsletterContent.ctaHref).toBe("https://tally.so/r/mR6RBl");
+  });
+
+  // ۲. تست وجود هاردکد target="_blank" درون کامپوننت کاملا به صورت خودکار
+  it("should ensure the HTML link inside Newsletter.astro has target='_blank' and safe rel attributes", () => {
+    // خواندن فایل کامپوننت از روی دیسک
+    const componentPath = path.resolve(
+      process.cwd(),
+      "src/components/Newsletter.astro",
+    );
+    const componentContent = fs.readFileSync(componentPath, "utf8");
+
+    // بررسی وجود دقیق اتربیوت‌ها روی تگ a در کامپوننت
+    expect(componentContent).toContain('target="_blank"');
+    expect(componentContent).toContain('rel="noopener noreferrer"');
+
+    // بررسی دقیق‌تر ساختار خط تگ a
+    const hasCorrectAnchorTag = componentContent.includes(
+      '<a target="_blank" rel="noopener noreferrer" href={content.ctaHref} class="newsletter-button">',
+    );
+    expect(hasCorrectAnchorTag).toBe(true);
+  });
+});

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -478,6 +478,7 @@ export function getFooterContent(city: City) {
         col: 2,
         text: "Subscribe to Newsletter",
         href: "https://tally.so/r/mR6RBl",
+        target: "_blank",
       },
       // { col: 2, text: 'Sponsorship Info', href: '/our-sponsors' },
 


### PR DESCRIPTION
Closes #138

### Changes made:
- Hardcoded `target="_blank"` and `rel="noopener noreferrer"` inside `Newsletter.astro` component.
- Updated configuration for `Newsletter333` in `src/lib/content.ts`.
- Added unit tests in `src/components/SubscribetoNewsletterButtom.test.ts` to verify the exact data structure and ensure the component source file guarantees the secure target attributes.

PTAL @vincent6767 