### PR TITLE
Release: schedule page, newsletter target-blank fix, and footer credit updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 dist/
 .output/
 
+# tasks
+tasks.md
+
 # dependencies
 node_modules/
 

--- a/src/components/Footer.test.ts
+++ b/src/components/Footer.test.ts
@@ -1,0 +1,29 @@
+// src/components/Footer.test.ts
+import { describe, test, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { getFooterContent } from "../lib/content";
+
+describe("Footer Component - LinkedIn social link", () => {
+  test("footer content data should contain a LinkedIn entry with the correct URL", () => {
+    const { social } = getFooterContent("vancouver");
+    const linkedIn = social?.find((item) => item.name === "LinkedIn");
+
+    expect(linkedIn).toBeDefined();
+    expect(linkedIn?.url).toBe("https://www.linkedin.com/company/canadiancloud/");
+  });
+
+  test("LinkedIn social link should open in a new tab with secure rel attributes", () => {
+    const componentPath = path.resolve(__dirname, "./Footer.astro");
+    const fileContent = fs.readFileSync(componentPath, "utf8");
+
+    // Social links (Instagram/LinkedIn) are rendered from content.social via
+    // a single <a> template, so verify that template opens in a new tab...
+    expect(fileContent).toMatch(
+      /<a\s+href={social\.url}\s+target="_blank"\s+rel="noopener noreferrer"/,
+    );
+
+    // ...and specifically renders a LinkedIn icon for the LinkedIn entry.
+    expect(fileContent).toMatch(/social\.name === "LinkedIn"/);
+  });
+});

--- a/src/components/Navigation.test.ts
+++ b/src/components/Navigation.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { getNavigationContent } from "../lib/content";
+
+describe("Navigation content - Schedule link", () => {
+  (["toronto", "vancouver"] as const).forEach((city) => {
+    it(`includes the Schedule link pointing at /#schedule for ${city}`, () => {
+      const { links } = getNavigationContent(city);
+      expect(links).toContainEqual({ text: "Schedule", href: "/#schedule" });
+    });
+  });
+});
+
+describe("Navigation.astro - renders links from content", () => {
+  it("maps over content.links so the Schedule link reaches the DOM", () => {
+    const componentPath = path.resolve(__dirname, "./Navigation.astro");
+    const source = fs.readFileSync(componentPath, "utf8");
+
+    expect(source).toMatch(/content\.links\.map\(/);
+  });
+});

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -19,7 +19,7 @@ const { content } = Astro.props;
 			{content.heading}
 		</h2>
 		<p class="newsletter-description">{content.description}</p>
-		<a href={content.ctaHref} class="newsletter-button">
+		<a target="_blank" rel="noopener noreferrer" href={content.ctaHref} class="newsletter-button">
 			{content.ctaText}
 		</a>
 	</div>

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -213,7 +213,7 @@ const timelineGroups = groupByStartTime(timelineEntries);
     flex-direction: column;
     gap: 1.5rem;
     padding: 3rem 1.5rem;
-    background: #0b0e14;
+    background: #000000;
     scroll-margin-top: 5rem;
   }
 

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -123,16 +123,9 @@ const timelineGroups = groupByStartTime(timelineEntries);
                 )}
               </div>
               <span class="timeline-duration">{entry.durationLabel}</span>
-              {entry.badges.map((badge) => (
-                <span
-                  class:list={[
-                    'timeline-badge',
-                    badge.startsWith('LIVE') ? 'timeline-badge--live' : '',
-                  ]}
-                >
-                  {badge}
-                </span>
-              ))}
+              {entry.badges
+                .filter((badge) => !badge.startsWith('LIVE'))
+                .map((badge) => <span class="timeline-badge">{badge}</span>)}
             </div>
           ))}
         </div>
@@ -576,11 +569,6 @@ const timelineGroups = groupByStartTime(timelineEntries);
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.15);
     color: white;
-  }
-
-  .timeline-badge--live {
-    background: #d43d1a;
-    background: oklch(0.68 0.19 25);
   }
 
   @media (min-width: 769px) {

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -1,189 +1,605 @@
 ---
-import { cityContent } from '../lib/cityContent';
+import {
+  venues,
+  slots,
+  sessions,
+  fullWidthRows,
+  legend,
+  filterTracks,
+  venueKeyText,
+  dateLine,
+} from '../lib/torontoSchedule';
+import { timelineEntries, groupByStartTime } from '../lib/scheduleFilter';
 
-// Regex to find URLs in a string
-const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+)/g;
+const rowStyle = `grid-template-rows: auto repeat(${slots.length}, minmax(2.75rem, auto));`;
+const venueLabel = (id: string) => venues.find((v) => v.id === id)?.label ?? '';
+const timelineGroups = groupByStartTime(timelineEntries);
 ---
 
 <section class="schedule" id="schedule">
-    <h2 class="section-heading">Schedule</h2>
-    <div id="wrapper">
-        {cityContent.vancouver.schedule.map((event) => {
-            return <div class="item">
-                {event.endTime ? (
-                    <p class="time">{event.startTime} - {event.endTime}</p>
-                ) : (
-                    <p class="time">{event.startTime}</p>
-                )}
-                <div class="details">
-                    {event.activities.map((activity, idx) => {
-                        const roles = event.activityRoles;
-                        const useRoles =
-                            roles && roles.length === event.activities.length;
-                        const isPrimary = useRoles
-                            ? roles[idx] === 'title'
-                            : idx < (event.primaryLineCount ?? 1);
-                        const activityText = activity.trim();
-                        return (
-                            <p class:list={["activity", isPrimary ? "activity-title" : "activity-meta"]}>
-                                {activityText.split(urlRegex).map(part => {
-                                    if (part.match(urlRegex)) {
-                                        const url = part.startsWith('www.') ? `http://${part}` : part;
-                                        return <a href={url} target="_blank" rel="noopener noreferrer">{part}</a>;
-                                    }
-                                    return part;
-                                })}
-                            </p>
-                        );
-                    })}
-                </div>
-            </div>
-        })}
+  <div class="schedule-header">
+    <h2 class="section-heading">Event Schedule</h2>
+    <p class="date-line">{dateLine}</p>
+    <ul class="legend" role="list">
+      {legend.map((entry) => (
+        <li class:list={['legend-chip', `legend-chip--${entry.track}`]}>
+          <span class="legend-swatch" aria-hidden="true"></span>
+          {entry.label}
+        </li>
+      ))}
+    </ul>
+    <p class="venue-key">{venueKeyText}</p>
+  </div>
+
+  <div class="grid-scroll">
+    <div class="grid" style={rowStyle}>
+      <div class="corner-cell" style="grid-column: 1; grid-row: 1;"></div>
+      {venues.map((venue, vi) => (
+        <div class="venue-header" style={`grid-column: ${vi + 2}; grid-row: 1;`}>
+          {venue.label}
+        </div>
+      ))}
+
+      {slots.map((slot, si) => (
+        <div class="time-cell" style={`grid-column: 1; grid-row: ${si + 2};`}>
+          {slot}
+        </div>
+      ))}
+
+      {sessions.map((session) => {
+        const venueIndex = venues.findIndex((v) => v.id === session.venue);
+        const rowIndex = slots.indexOf(session.start);
+        return (
+          <div
+            class:list={['session', `session--${session.track}`]}
+            style={`grid-column: ${venueIndex + 2}; grid-row: ${rowIndex + 2} / span ${session.slots};`}
+          >
+            <p class="session-title">{session.title}</p>
+            {session.badges.map((badge) => (
+              <span
+                class:list={[
+                  'session-badge',
+                  badge.startsWith('LIVE') ? 'session-badge--live' : '',
+                ]}
+              >
+                {badge}
+              </span>
+            ))}
+          </div>
+        );
+      })}
+
+      {fullWidthRows.map((row) => {
+        const rowIndex = slots.indexOf(row.start);
+        // Column 1 is the time column; venue columns start at 2 and follow
+        // `venues` order, so a row's span ends right after its last covered
+        // venue (leaving any trailing venues, e.g. Workshops, to keep
+        // rendering their own session cell in that row).
+        const endColumn = row.venues.length + 2;
+        return (
+          <div
+            class:list={['full-width-row', row.id === 'food-break' ? 'full-width-row--food' : '']}
+            style={`grid-column: 1 / ${endColumn}; grid-row: ${rowIndex + 2};`}
+          >
+            {row.title} &middot; {row.start}
+          </div>
+        );
+      })}
+
+      <div class="now-line" id="schedule-now-line" hidden></div>
     </div>
+  </div>
+
+  <div class="timeline">
+    <ul class="filter-chips" role="list">
+      {filterTracks.map((track) => (
+        <li>
+          <button
+            type="button"
+            class="filter-chip"
+            data-track={track.id}
+            aria-pressed={track.id === 'all' ? 'true' : 'false'}
+          >
+            {track.label}
+          </button>
+        </li>
+      ))}
+    </ul>
+
+    {timelineGroups.map((group) => (
+      <div class="timeline-group" data-start={group.startMinutes}>
+        <p class="timeline-time">{group.start}</p>
+        <div class="timeline-entries">
+          {group.entries.map((entry) => (
+            <div
+              class="timeline-entry"
+              data-venue={entry.venue ?? ''}
+              data-always-visible={entry.alwaysVisible ? 'true' : 'false'}
+            >
+              <div class="timeline-entry-main">
+                <p class="timeline-entry-title">{entry.title}</p>
+                {entry.venue && (
+                  <p class="timeline-entry-venue">{venueLabel(entry.venue)}</p>
+                )}
+              </div>
+              <span class="timeline-duration">{entry.durationLabel}</span>
+              {entry.badges.map((badge) => (
+                <span
+                  class:list={[
+                    'timeline-badge',
+                    badge.startsWith('LIVE') ? 'timeline-badge--live' : '',
+                  ]}
+                >
+                  {badge}
+                </span>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    ))}
+  </div>
 </section>
 
 <script>
-    import { getCityStore } from '../lib/cityStore';
-    import type { City } from '../lib/content';
+  function initScheduleFilterChips() {
+    const chips = document.querySelectorAll<HTMLButtonElement>('.filter-chip');
+    const entries = document.querySelectorAll<HTMLElement>('.timeline-entry');
+    const groups = document.querySelectorAll<HTMLElement>('.timeline-group');
 
-    function syncScheduleVisibility(city: City) {
-        const el = document.querySelector('.schedule') as HTMLElement | null;
-        if (!el) return;
-        const show = city === 'vancouver';
-        el.classList.toggle('schedule--hidden', !show);
-        el.setAttribute('aria-hidden', show ? 'false' : 'true');
+    function applyFilter(track: string) {
+      entries.forEach((entry) => {
+        const venue = entry.dataset.venue;
+        const alwaysVisible = entry.dataset.alwaysVisible === 'true';
+        const show = track === 'all' || alwaysVisible || venue === track;
+        entry.classList.toggle('is-hidden', !show);
+      });
+      groups.forEach((group) => {
+        const hasVisible = group.querySelector('.timeline-entry:not(.is-hidden)');
+        group.classList.toggle('is-hidden', !hasVisible);
+      });
     }
 
-    function initCityAwareSchedule() {
-        const cityStore = getCityStore();
-        cityStore.init();
-        syncScheduleVisibility(cityStore.getCity());
-        cityStore.subscribe(syncScheduleVisibility);
+    chips.forEach((chip) => {
+      chip.addEventListener('click', () => {
+        chips.forEach((c) => c.setAttribute('aria-pressed', 'false'));
+        chip.setAttribute('aria-pressed', 'true');
+        applyFilter(chip.dataset.track ?? 'all');
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initScheduleFilterChips);
+  } else {
+    initScheduleFilterChips();
+  }
+</script>
+
+<script>
+  import { getNowLinePosition } from '../lib/scheduleNow';
+
+  function positionNowLine() {
+    const line = document.getElementById('schedule-now-line');
+    const grid = document.querySelector<HTMLElement>('.grid');
+    if (!line || !grid) return;
+
+    const position = getNowLinePosition(new Date());
+    if (position === null) {
+      line.hidden = true;
+      return;
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', initCityAwareSchedule);
-    } else {
-        initCityAwareSchedule();
-    }
+    const timeCells = Array.from(
+      grid.querySelectorAll<HTMLElement>('.time-cell'),
+    );
+    const lowerIndex = Math.floor(position);
+    const upperIndex = Math.min(lowerIndex + 1, timeCells.length - 1);
+    const lowerCell = timeCells[lowerIndex];
+    const upperCell = timeCells[upperIndex];
+    if (!lowerCell || !upperCell) return;
+
+    const fraction = position - lowerIndex;
+    const gridTop = grid.getBoundingClientRect().top;
+    const lowerTop = lowerCell.getBoundingClientRect().top - gridTop;
+    const upperTop = upperCell.getBoundingClientRect().top - gridTop;
+
+    line.style.top = `${lowerTop + (upperTop - lowerTop) * fraction}px`;
+    line.hidden = false;
+  }
+
+  function initScheduleNowLine() {
+    positionNowLine();
+    window.setInterval(positionNowLine, 60_000);
+    window.addEventListener('resize', positionNowLine);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initScheduleNowLine);
+  } else {
+    initScheduleNowLine();
+  }
 </script>
 
 <style>
-    .schedule.schedule--hidden {
-        display: none !important;
-    }
+  .schedule {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 3rem 1.5rem;
+    background: #0b0e14;
+    scroll-margin-top: 5rem;
+  }
 
+  .schedule-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    text-align: center;
+  }
+
+  .section-heading {
+    font-family: var(--font-display);
+    font-size: 2.5rem;
+    margin: 0;
+    color: rgb(255, 193, 77);
+  }
+
+  .date-line {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.75);
+    font-family: var(--font-body);
+  }
+
+  .legend {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .legend-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8125rem;
+    color: rgba(255, 255, 255, 0.85);
+    font-family: var(--font-body);
+  }
+
+  .legend-swatch {
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 50%;
+    display: inline-block;
+  }
+
+  .legend-chip--main .legend-swatch { background: #5b8def; background: oklch(0.75 0.11 255); }
+  .legend-chip--community .legend-swatch { background: #3dc9b0; background: oklch(0.75 0.11 185); }
+  .legend-chip--aws .legend-swatch { background: #e8a33d; background: oklch(0.78 0.11 65); }
+  .legend-chip--hackathon .legend-swatch { background: #c86adb; background: oklch(0.76 0.12 310); }
+  .legend-chip--workshops .legend-swatch { background: #4fc97a; background: oklch(0.75 0.11 150); }
+  .legend-chip--food .legend-swatch { background: #e0c24f; background: oklch(0.8 0.1 95); }
+
+  .venue-key {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 0.875rem;
+    font-family: var(--font-body);
+  }
+
+  .grid-scroll {
+    width: 100%;
+    max-width: 1400px;
+    margin: 0 auto;
+    overflow-x: auto;
+    border: 1px solid #1e2534;
+    border-radius: 0.75rem;
+  }
+
+  .grid {
+    position: relative;
+    display: grid;
+    grid-template-columns: max-content repeat(6, minmax(150px, 1fr));
+    min-width: 900px;
+  }
+
+  .now-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: #d43d1a;
+    background: oklch(0.68 0.19 25);
+    z-index: 5;
+    pointer-events: none;
+  }
+
+  .now-line::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: inherit;
+  }
+
+  @media (max-width: 768px) {
+    .now-line {
+      display: none !important;
+    }
+  }
+
+  .corner-cell,
+  .venue-header,
+  .time-cell {
+    background: #10141d;
+    border-bottom: 1px solid #1e2534;
+    border-right: 1px solid #1e2534;
+  }
+
+  .venue-header {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    padding: 0.75rem 0.5rem;
+    font-family: var(--font-display);
+    font-size: 0.8125rem;
+    letter-spacing: 0.02em;
+    color: rgba(255, 255, 255, 0.92);
+    text-align: center;
+  }
+
+  .corner-cell {
+    position: sticky;
+    top: 0;
+    left: 0;
+    z-index: 4;
+  }
+
+  .time-cell {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    padding: 0.5rem 0.75rem;
+    font-family: var(--font-body);
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.6);
+    white-space: nowrap;
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .session {
+    margin: 2px;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    overflow: hidden;
+  }
+
+  .session-title {
+    margin: 0;
+    font-size: 0.8125rem;
+    line-height: 1.3;
+    color: white;
+    font-family: var(--font-body);
+  }
+
+  .session-badge {
+    align-self: flex-start;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+  }
+
+  .session-badge--live {
+    background: #d43d1a;
+    background: oklch(0.68 0.19 25);
+  }
+
+  .session--main {
+    background: rgba(91, 141, 239, 0.15);
+    background: oklch(0.75 0.11 255 / 0.15);
+    border-color: #5b8def;
+    border-color: oklch(0.75 0.11 255);
+  }
+
+  .session--community {
+    background: rgba(61, 201, 176, 0.15);
+    background: oklch(0.75 0.11 185 / 0.15);
+    border-color: #3dc9b0;
+    border-color: oklch(0.75 0.11 185);
+  }
+
+  .session--aws {
+    background: rgba(232, 163, 61, 0.15);
+    background: oklch(0.78 0.11 65 / 0.15);
+    border-color: #e8a33d;
+    border-color: oklch(0.78 0.11 65);
+  }
+
+  .session--hackathon {
+    background: rgba(200, 106, 219, 0.15);
+    background: oklch(0.76 0.12 310 / 0.15);
+    border-color: #c86adb;
+    border-color: oklch(0.76 0.12 310);
+  }
+
+  .session--workshops {
+    background: rgba(79, 201, 122, 0.15);
+    background: oklch(0.75 0.11 150 / 0.15);
+    border-color: #4fc97a;
+    border-color: oklch(0.75 0.11 150);
+  }
+
+  .session--showcase {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .full-width-row {
+    margin: 2px;
+    padding: 0.6rem 1rem;
+    border-radius: 0.5rem;
+    background: rgba(224, 194, 79, 0.12);
+    background: oklch(0.8 0.1 95 / 0.12);
+    border: 1px dashed #e0c24f;
+    border: 1px dashed oklch(0.8 0.1 95);
+    color: white;
+    font-family: var(--font-display);
+    font-size: 0.9rem;
+    text-align: center;
+  }
+
+  .full-width-row--food {
+    background: rgba(224, 194, 79, 0.18);
+    background: oklch(0.8 0.1 95 / 0.18);
+  }
+
+  .timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    width: 100%;
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  .filter-chips {
+    display: flex;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0.25rem 0;
+    overflow-x: auto;
+  }
+
+  .filter-chip {
+    flex: 0 0 auto;
+    padding: 0.4rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid #1e2534;
+    background: #10141d;
+    color: rgba(255, 255, 255, 0.75);
+    font-family: var(--font-body);
+    font-size: 0.8125rem;
+    cursor: pointer;
+  }
+
+  .filter-chip[aria-pressed="true"] {
+    background: rgba(255, 193, 77, 0.15);
+    border-color: rgb(255, 193, 77);
+    color: white;
+  }
+
+  .timeline-group.is-hidden {
+    display: none;
+  }
+
+  .timeline-time {
+    margin: 0 0 0.5rem 0;
+    color: rgba(255, 255, 255, 0.6);
+    font-family: var(--font-body);
+    font-size: 0.8125rem;
+  }
+
+  .timeline-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .timeline-entry {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.75rem 0.9rem;
+    border-radius: 0.6rem;
+    border: 1px solid #1e2534;
+    background: #10141d;
+  }
+
+  .timeline-entry.is-hidden {
+    display: none;
+  }
+
+  .timeline-entry-main {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .timeline-entry-title {
+    margin: 0;
+    color: white;
+    font-family: var(--font-body);
+    font-size: 0.9375rem;
+  }
+
+  .timeline-entry-venue {
+    margin: 0.15rem 0 0 0;
+    color: rgba(255, 255, 255, 0.6);
+    font-family: var(--font-body);
+    font-size: 0.75rem;
+  }
+
+  .timeline-duration {
+    flex: 0 0 auto;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.08);
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+  }
+
+  .timeline-badge {
+    flex: 0 0 auto;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    padding: 0.1rem 0.4rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+  }
+
+  .timeline-badge--live {
+    background: #d43d1a;
+    background: oklch(0.68 0.19 25);
+  }
+
+  @media (min-width: 769px) {
     .schedule {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        padding: 3rem 1.5rem;
-        background: black;
-        scroll-margin-top: 5rem;
-    }
-    .section-heading {
-        font-family: 'Squada One', system-ui, sans-serif;
-        font-size: 2.5rem;
-        text-align: center;
-        margin: 0 0 3rem 0;
-        color: rgb(255, 193, 77);
-    }
-    #wrapper {
-        width: 100%;
-        max-width: 1200px;
-        display: flex;
-        flex-direction: column;
-        background: rgba(61, 120, 171, 0.08);
-        border: 1px solid rgba(61, 120, 171, 0.2);
-        border-radius: 1rem;
-        overflow: hidden;
-    }
-    .item {
-        display: flex;
-        flex-direction: column;
-        gap: 0.45rem;
-        padding: 0.65rem 0.75rem;
+      padding: 4.5rem 2rem;
     }
 
-    .item:not(:last-child) {
-        border-bottom: 1px solid rgba(255, 255, 255, 0.16);
+    .section-heading {
+      font-size: 4rem;
     }
-    .time {
-        margin: 0;
-        color: rgba(255, 255, 255, 0.88);
-        font-size: 1rem;
-        line-height: 1.4;
-        white-space: nowrap;
-        padding-left: 0.25rem;
-        text-align: left;
+
+    .timeline {
+      display: none;
     }
-    .details {
-        display: flex;
-        flex-direction: column;
-        gap: 0.2rem;
+  }
+
+  @media (max-width: 768px) {
+    .grid-scroll {
+      display: none;
     }
-    .activity {
-        margin: 0;
-        color: white;
-        line-height: 1.3;
-    }
-    .activity-title {
-        font-size: 1.25rem;
-        font-weight: 600;
-        color: white;
-    }
-    .activity-meta {
-        font-size: 0.875rem;
-        color: white;
-        opacity: 0.7;
-    }
-    .activity-meta::before {
-        content: "◉";
-        display: inline-block;
-        margin-right: 0.35rem;
-        font-size: 0.75em;
-        vertical-align: middle;
-    }
-    .activity-meta a {
-        color: inherit;
-        text-decoration: underline;
-    }
-    @media (min-width: 769px) {
-        .schedule {
-            padding: 4.5rem 2rem;
-        }
-        .section-heading {
-            font-size: 4rem;
-        }
-        .item {
-            display: grid;
-            grid-template-columns: 30% 70%;
-            align-items: start;
-            gap: 1rem;
-            padding: 0.85rem 1rem;
-        }
-        .time {
-            font-size: 1.125rem;
-            font-weight: 500;
-            padding-left: 1.5rem;
-            text-align: center;
-        }
-        .activity-title {
-            font-size: 1.25rem;
-        }
-        .activity-meta {
-            font-size: 0.875rem;
-        }
-    }
-    @media (max-width: 768px) {
-        .time {
-            font-size: 0.875rem;
-        }
-        .activity-title {
-            font-size: 1rem;
-        }
-        .activity-meta {
-            font-size: 0.8125rem;
-        }
-    }
+  }
 </style>

--- a/src/components/Schedule.astro
+++ b/src/components/Schedule.astro
@@ -55,16 +55,9 @@ const timelineGroups = groupByStartTime(timelineEntries);
             style={`grid-column: ${venueIndex + 2}; grid-row: ${rowIndex + 2} / span ${session.slots};`}
           >
             <p class="session-title">{session.title}</p>
-            {session.badges.map((badge) => (
-              <span
-                class:list={[
-                  'session-badge',
-                  badge.startsWith('LIVE') ? 'session-badge--live' : '',
-                ]}
-              >
-                {badge}
-              </span>
-            ))}
+            {session.badges
+              .filter((badge) => !badge.startsWith('LIVE'))
+              .map((badge) => <span class="session-badge">{badge}</span>)}
           </div>
         );
       })}
@@ -398,11 +391,6 @@ const timelineGroups = groupByStartTime(timelineEntries);
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.15);
     color: white;
-  }
-
-  .session-badge--live {
-    background: #d43d1a;
-    background: oklch(0.68 0.19 25);
   }
 
   .session--main {

--- a/src/components/Schedule.test.ts
+++ b/src/components/Schedule.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs";
+import path from "path";
+
+const componentPath = path.resolve(__dirname, "./Schedule.astro");
+let source: string;
+
+beforeAll(() => {
+  source = fs.readFileSync(componentPath, "utf8");
+});
+
+describe("Schedule.astro - section anchor", () => {
+  it("keeps id=\"schedule\" and scroll-margin-top for the sticky nav anchor", () => {
+    expect(source).toMatch(/id="schedule"/);
+    expect(source).toMatch(/scroll-margin-top/);
+  });
+});
+
+describe("Schedule.astro - data source", () => {
+  it("imports the Toronto schedule data module and drops the Vancouver/cityContent path", () => {
+    expect(source).toMatch(/from ['"]\.\.\/lib\/torontoSchedule['"]/);
+    expect(source).not.toMatch(/cityContent/);
+    expect(source).not.toMatch(/vancouver/i);
+  });
+});
+
+describe("Schedule.astro - venue key", () => {
+  it("renders the venue-key line from the exported constant, not hardcoded prose", () => {
+    expect(source).toMatch(/\{venueKeyText\}/);
+    expect(source).not.toMatch(
+      /3 stages \+ workshops across 5 levels \+ basement hackathon/,
+    );
+  });
+});
+
+describe("Schedule.astro - grid data-driven rendering", () => {
+  it("iterates the data module's venues and sessions collections to build the grid", () => {
+    expect(source).toMatch(/venues\.map\(/);
+    expect(source).toMatch(/sessions\.map\(/);
+    expect(source).toMatch(/fullWidthRows\.map\(/);
+  });
+});
+
+describe("Schedule.astro - full-width row column span respects data", () => {
+  it("computes each full-width row's grid-column span from row.venues instead of hardcoding every column", () => {
+    expect(source).toMatch(/row\.venues/);
+    expect(source).not.toMatch(/grid-column:\s*1\s*\/\s*-1/);
+  });
+});
+
+describe("Schedule.astro - event-day now line", () => {
+  it("wires the pure now-line position math into a dedicated line element", () => {
+    expect(source).toMatch(/from ['"]\.\.\/lib\/scheduleNow['"]/);
+    expect(source).toMatch(/getNowLinePosition/);
+    expect(source).toMatch(/now-line/);
+  });
+});
+
+describe("Schedule.astro - no Vancouver-only visibility gating", () => {
+  it("has no city-based hide/show logic left over from the Vancouver gating", () => {
+    expect(source).not.toMatch(/schedule--hidden/);
+    expect(source).not.toMatch(/syncScheduleVisibility/);
+    expect(source).not.toMatch(/setAttribute\(\s*['"]aria-hidden['"]/);
+    expect(source).not.toMatch(/cityStore/);
+  });
+});
+
+describe("index.astro - Schedule section placement", () => {
+  it("renders CallToActions, then Schedule, then WhatIsCloudSummit in that order", () => {
+    const indexPath = path.resolve(__dirname, "../pages/index.astro");
+    const indexSource = fs.readFileSync(indexPath, "utf8");
+
+    const ctaIndex = indexSource.search(/<CallToActions\s*\/>/);
+    const scheduleIndex = indexSource.search(/<Schedule\s*\/>/);
+    const whatIsIndex = indexSource.search(/<WhatIsCloudSummit\b/);
+
+    expect(ctaIndex).toBeGreaterThan(-1);
+    expect(scheduleIndex).toBeGreaterThan(-1);
+    expect(whatIsIndex).toBeGreaterThan(-1);
+    expect(ctaIndex).toBeLessThan(scheduleIndex);
+    expect(scheduleIndex).toBeLessThan(whatIsIndex);
+  });
+});
+
+describe("Schedule.astro - mobile timeline and filter chips", () => {
+  it("imports the pure grouping logic for the server-rendered timeline instead of reimplementing it inline", () => {
+    expect(source).toMatch(/from ['"]\.\.\/lib\/scheduleFilter['"]/);
+    expect(source).toMatch(/groupByStartTime/);
+  });
+
+  it("the inline script's filter predicate mirrors scheduleFilter's alwaysVisible-or-track-match rule via DOM data attributes only", () => {
+    expect(source).toMatch(/dataset\.venue/);
+    expect(source).toMatch(/alwaysVisible/i);
+  });
+
+  it("renders a filter chip per track", () => {
+    expect(source).toMatch(/filterTracks\.map\(/);
+  });
+
+  it("marks always-visible (food break / conclusion / after party) entries in the DOM", () => {
+    expect(source).toMatch(/data-always-visible/);
+  });
+});

--- a/src/components/SubscribetoNewsletterButtom.test.ts
+++ b/src/components/SubscribetoNewsletterButtom.test.ts
@@ -10,13 +10,12 @@ describe("Newsletter Target Buttons Unit Tests (#138)", () => {
   // 1. Testing data structure integrity (Content Data)
   it("should verify the content structure for Newsletter is correctly configured", () => {
     expect(newsletterContent).toBeDefined();
-    expect(newsletterContent.ctaText).toBe("Subscribe to Newsletter"); // اصلاح شده بر اساس دیتای واقعی فایل شما
+    expect(newsletterContent.ctaText).toBe("Subscribe to Newsletter");
     expect(newsletterContent.ctaHref).toBe("https://tally.so/r/mR6RBl");
   });
 
   // 2. Testing the presence of hardcoded target="_blank" within the component
   it("should ensure the HTML link inside Newsletter.astro has target='_blank' and safe rel attributes", () => {
-    // Reading the component file from disk
     const componentPath = path.resolve(
       process.cwd(),
       "src/components/Newsletter.astro",

--- a/src/components/SubscribetoNewsletterButtom.test.ts
+++ b/src/components/SubscribetoNewsletterButtom.test.ts
@@ -7,14 +7,14 @@ const mockCity = "vancouver";
 const footerContent = getFooterContent(mockCity);
 
 describe("Newsletter Target Buttons Unit Tests (#138)", () => {
-  // ۱. تست صحت ساختار داده‌ها (Content Data)
+  // 1. Testing data structure integrity (Content Data)
   it("should verify the content structure for Newsletter is correctly configured", () => {
     expect(newsletterContent).toBeDefined();
     expect(newsletterContent.ctaText).toBe("Subscribe to Newsletter"); // اصلاح شده بر اساس دیتای واقعی فایل شما
     expect(newsletterContent.ctaHref).toBe("https://tally.so/r/mR6RBl");
   });
 
-  // ۲. تست وجود هاردکد target="_blank" درون کامپوننت کاملا به صورت خودکار
+  // 2. Testing the presence of hardcoded target="_blank" within the component
   it("should ensure the HTML link inside Newsletter.astro has target='_blank' and safe rel attributes", () => {
     // خواندن فایل کامپوننت از روی دیسک
     const componentPath = path.resolve(
@@ -23,11 +23,11 @@ describe("Newsletter Target Buttons Unit Tests (#138)", () => {
     );
     const componentContent = fs.readFileSync(componentPath, "utf8");
 
-    // بررسی وجود دقیق اتربیوت‌ها روی تگ a در کامپوننت
+    // Checking the exact presence of attributes on the <a> tag in the component
     expect(componentContent).toContain('target="_blank"');
     expect(componentContent).toContain('rel="noopener noreferrer"');
 
-    // بررسی دقیق‌تر ساختار خط تگ a
+    // Checking the exact structure of the <a> tag in the component
     const hasCorrectAnchorTag = componentContent.includes(
       '<a target="_blank" rel="noopener noreferrer" href={content.ctaHref} class="newsletter-button">',
     );

--- a/src/components/SubscribetoNewsletterButtom.test.ts
+++ b/src/components/SubscribetoNewsletterButtom.test.ts
@@ -16,7 +16,7 @@ describe("Newsletter Target Buttons Unit Tests (#138)", () => {
 
   // 2. Testing the presence of hardcoded target="_blank" within the component
   it("should ensure the HTML link inside Newsletter.astro has target='_blank' and safe rel attributes", () => {
-    // خواندن فایل کامپوننت از روی دیسک
+    // Reading the component file from disk
     const componentPath = path.resolve(
       process.cwd(),
       "src/components/Newsletter.astro",

--- a/src/components/SubscribetoNewsletterButtom.test.ts
+++ b/src/components/SubscribetoNewsletterButtom.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getFooterContent, newsletterContent } from "../lib/content";
+import fs from "fs";
+import path from "path";
+
+const mockCity = "vancouver";
+const footerContent = getFooterContent(mockCity);
+
+describe("Newsletter Target Buttons Unit Tests (#138)", () => {
+  // ۱. تست صحت ساختار داده‌ها (Content Data)
+  it("should verify the content structure for Newsletter is correctly configured", () => {
+    expect(newsletterContent).toBeDefined();
+    expect(newsletterContent.ctaText).toBe("Subscribe to Newsletter"); // اصلاح شده بر اساس دیتای واقعی فایل شما
+    expect(newsletterContent.ctaHref).toBe("https://tally.so/r/mR6RBl");
+  });
+
+  // ۲. تست وجود هاردکد target="_blank" درون کامپوننت کاملا به صورت خودکار
+  it("should ensure the HTML link inside Newsletter.astro has target='_blank' and safe rel attributes", () => {
+    // خواندن فایل کامپوننت از روی دیسک
+    const componentPath = path.resolve(
+      process.cwd(),
+      "src/components/Newsletter.astro",
+    );
+    const componentContent = fs.readFileSync(componentPath, "utf8");
+
+    // بررسی وجود دقیق اتربیوت‌ها روی تگ a در کامپوننت
+    expect(componentContent).toContain('target="_blank"');
+    expect(componentContent).toContain('rel="noopener noreferrer"');
+
+    // بررسی دقیق‌تر ساختار خط تگ a
+    const hasCorrectAnchorTag = componentContent.includes(
+      '<a target="_blank" rel="noopener noreferrer" href={content.ctaHref} class="newsletter-button">',
+    );
+    expect(hasCorrectAnchorTag).toBe(true);
+  });
+});

--- a/src/components/TorontoCloudSummitDeveloper2026.test.ts
+++ b/src/components/TorontoCloudSummitDeveloper2026.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { websiteCredits } from "../lib/content";
+
+describe("Website Credits Unit Tests for Toronto Cloud Summit (#142)", () => {
+  it("should verify that website credits array contains exactly Ahmad and Vincent with correct profiles", () => {
+    expect(websiteCredits).toBeDefined();
+
+    expect(websiteCredits.length).toBe(2);
+
+    expect(websiteCredits[0].name).toBe("Ahmad");
+    expect(websiteCredits[0].link).toBe(
+      "https://www.linkedin.com/in/ahmad-salempoor/",
+    );
+
+    expect(websiteCredits[1].name).toBe("Vincent");
+    expect(websiteCredits[1].link).toBe(
+      "https://www.linkedin.com/in/vincent-vincent-360b71104/",
+    );
+  });
+});

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -414,7 +414,10 @@ export interface VenueLogisticsSectionNewVersion {
 }
 
 /** Footer line: Website by … — optional LinkedIn per name (same pattern as aws-community-day). */
-export const websiteCredits: Array<{ name: string; link: string | null }> = [
+export const websiteCredits2026_Vancouver: Array<{
+  name: string;
+  link: string | null;
+}> = [
   {
     name: "Nichanun (Luck)",
     link: "https://www.linkedin.com/in/nichanun-pong/",
@@ -430,6 +433,17 @@ export const websiteCredits: Array<{ name: string; link: string | null }> = [
   {
     name: "Laurie",
     link: "https://www.linkedin.com/in/laurieyeh1/",
+  },
+];
+
+export const websiteCredits: Array<{ name: string; link: string | null }> = [
+  {
+    name: "Ahmad",
+    link: "https://www.linkedin.com/in/ahmad-salempoor/",
+  },
+  {
+    name: "Vincent",
+    link: "https://www.linkedin.com/in/vincent-vincent-360b71104/",
   },
 ];
 

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -478,6 +478,7 @@ export function getFooterContent(city: City) {
         col: 2,
         text: "Subscribe to Newsletter",
         href: "https://tally.so/r/mR6RBl",
+        target: "_blank",
       },
       // { col: 2, text: 'Sponsorship Info', href: '/our-sponsors' },
 

--- a/src/lib/scheduleFilter.test.ts
+++ b/src/lib/scheduleFilter.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import {
+  timelineEntries,
+  groupByStartTime,
+  filterByTrack,
+  formatDuration,
+} from "./scheduleFilter";
+import { sessions, fullWidthRows } from "./torontoSchedule";
+
+describe("scheduleFilter - groupByStartTime", () => {
+  const groups = groupByStartTime(timelineEntries);
+
+  it("returns groups in chronological order", () => {
+    const startTimes = groups.map((g) => g.startMinutes);
+    const sorted = [...startTimes].sort((a, b) => a - b);
+    expect(startTimes).toEqual(sorted);
+  });
+
+  it("covers every timeline entry exactly once", () => {
+    const idsInGroups = groups.flatMap((g) => g.entries.map((e) => e.id));
+    expect(idsInGroups).toHaveLength(timelineEntries.length);
+    expect(new Set(idsInGroups).size).toBe(timelineEntries.length);
+    const expectedIds = new Set(timelineEntries.map((e) => e.id));
+    idsInGroups.forEach((id) => expect(expectedIds.has(id)).toBe(true));
+  });
+});
+
+describe("scheduleFilter - filterByTrack", () => {
+  it("'all' returns everything", () => {
+    expect(filterByTrack("all", timelineEntries)).toHaveLength(
+      timelineEntries.length,
+    );
+  });
+
+  it("'aws' returns only AWS sessions plus the always-visible full-width rows", () => {
+    const result = filterByTrack("aws", timelineEntries);
+    const resultIds = new Set(result.map((e) => e.id));
+
+    const awsSessionIds = sessions
+      .filter((s) => s.venue === "aws")
+      .map((s) => s.id);
+    const fullWidthIds = fullWidthRows.map((r) => r.id);
+
+    expect(resultIds.size).toBe(awsSessionIds.length + fullWidthIds.length);
+    awsSessionIds.forEach((id) => expect(resultIds.has(id)).toBe(true));
+    fullWidthIds.forEach((id) => expect(resultIds.has(id)).toBe(true));
+
+    const otherVenueSession = sessions.find((s) => s.venue === "community");
+    expect(resultIds.has(otherVenueSession!.id)).toBe(false);
+  });
+
+  (["main", "community", "hackathon", "workshops"] as const).forEach(
+    (track) => {
+      it(`'${track}' returns only that track's sessions plus the always-visible rows`, () => {
+        const result = filterByTrack(track, timelineEntries);
+        const resultIds = new Set(result.map((e) => e.id));
+
+        const trackSessionIds = sessions
+          .filter((s) => s.venue === track)
+          .map((s) => s.id);
+        const fullWidthIds = fullWidthRows.map((r) => r.id);
+
+        expect(resultIds.size).toBe(
+          trackSessionIds.length + fullWidthIds.length,
+        );
+        trackSessionIds.forEach((id) => expect(resultIds.has(id)).toBe(true));
+        fullWidthIds.forEach((id) => expect(resultIds.has(id)).toBe(true));
+      });
+    },
+  );
+});
+
+describe("scheduleFilter - duration labels", () => {
+  it("formats known durations as 30m / 60m / 90m / 2.5h", () => {
+    expect(formatDuration(30)).toBe("30m");
+    expect(formatDuration(60)).toBe("60m");
+    expect(formatDuration(90)).toBe("90m");
+    expect(formatDuration(150)).toBe("2.5h");
+  });
+
+  it("computes the panel's duration label as 60m and the 90-minute workshop as 90m", () => {
+    const panel = timelineEntries.find((e) => e.id === "main-5");
+    const longWorkshop = timelineEntries.find((e) => e.id === "workshops-3");
+    expect(panel?.durationLabel).toBe("60m");
+    expect(longWorkshop?.durationLabel).toBe("90m");
+  });
+});

--- a/src/lib/scheduleFilter.ts
+++ b/src/lib/scheduleFilter.ts
@@ -1,0 +1,98 @@
+import {
+  sessions,
+  fullWidthRows,
+  type Session,
+  type FullWidthRow,
+  type VenueId,
+} from "./torontoSchedule";
+
+export interface TimelineEntry {
+  id: string;
+  title: string;
+  start: string;
+  startMinutes: number;
+  end: string;
+  endMinutes: number;
+  venue: VenueId | null;
+  badges: string[];
+  alwaysVisible: boolean;
+  durationLabel: string;
+}
+
+export interface TimelineGroup {
+  start: string;
+  startMinutes: number;
+  entries: TimelineEntry[];
+}
+
+export type TrackFilter = VenueId | "all";
+
+/** Renders minute durations as the site's badge format: 30m / 60m / 90m / 2.5h. */
+export function formatDuration(minutes: number): string {
+  if (minutes < 120) return `${minutes}m`;
+  return `${minutes / 60}h`;
+}
+
+function fromSession(session: Session): TimelineEntry {
+  return {
+    id: session.id,
+    title: session.title,
+    start: session.start,
+    startMinutes: session.startMinutes,
+    end: session.end,
+    endMinutes: session.endMinutes,
+    venue: session.venue,
+    badges: session.badges,
+    alwaysVisible: false,
+    durationLabel: formatDuration(session.endMinutes - session.startMinutes),
+  };
+}
+
+function fromFullWidthRow(row: FullWidthRow): TimelineEntry {
+  return {
+    id: row.id,
+    title: row.title,
+    start: row.start,
+    startMinutes: row.startMinutes,
+    end: row.end,
+    endMinutes: row.endMinutes,
+    venue: null,
+    badges: [],
+    alwaysVisible: true,
+    durationLabel: formatDuration(row.endMinutes - row.startMinutes),
+  };
+}
+
+export function buildTimelineEntries(): TimelineEntry[] {
+  return [
+    ...sessions.map(fromSession),
+    ...fullWidthRows.map(fromFullWidthRow),
+  ];
+}
+
+export const timelineEntries: TimelineEntry[] = buildTimelineEntries();
+
+export function groupByStartTime(entries: TimelineEntry[]): TimelineGroup[] {
+  const byStart = new Map<number, TimelineGroup>();
+  for (const entry of entries) {
+    let group = byStart.get(entry.startMinutes);
+    if (!group) {
+      group = {
+        start: entry.start,
+        startMinutes: entry.startMinutes,
+        entries: [],
+      };
+      byStart.set(entry.startMinutes, group);
+    }
+    group.entries.push(entry);
+  }
+  return [...byStart.values()].sort((a, b) => a.startMinutes - b.startMinutes);
+}
+
+export function filterByTrack(
+  track: TrackFilter,
+  entries: TimelineEntry[],
+): TimelineEntry[] {
+  if (track === "all") return entries;
+  return entries.filter((entry) => entry.alwaysVisible || entry.venue === track);
+}

--- a/src/lib/scheduleNow.test.ts
+++ b/src/lib/scheduleNow.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getNowLinePosition } from "./scheduleNow";
+
+describe("scheduleNow - only renders on event day (America/Toronto)", () => {
+  it("returns null for dates that aren't Aug 29, 2026", () => {
+    expect(getNowLinePosition(new Date("2026-08-28T18:00:00Z"))).toBeNull();
+    expect(getNowLinePosition(new Date("2026-07-19T18:00:00Z"))).toBeNull();
+  });
+
+  it("returns null when the UTC calendar day is Aug 29 but the Toronto-local day is still Aug 28", () => {
+    // 2026-08-29T02:00:00Z is 2026-08-28 22:00 in America/Toronto (EDT, UTC-4).
+    expect(getNowLinePosition(new Date("2026-08-29T02:00:00Z"))).toBeNull();
+  });
+});
+
+describe("scheduleNow - only renders within event hours", () => {
+  it("returns null before 12:00pm Toronto time on event day", () => {
+    // 15:00 UTC = 11:00 AM EDT
+    expect(getNowLinePosition(new Date("2026-08-29T15:00:00Z"))).toBeNull();
+  });
+
+  it("returns null after 6:30pm Toronto time on event day", () => {
+    // 23:00 UTC = 7:00 PM EDT
+    expect(getNowLinePosition(new Date("2026-08-29T23:00:00Z"))).toBeNull();
+  });
+});
+
+describe("scheduleNow - fractional slot position for known times", () => {
+  it("12:00pm Toronto is position 0", () => {
+    // 16:00 UTC = 12:00 PM EDT
+    expect(getNowLinePosition(new Date("2026-08-29T16:00:00Z"))).toBe(0);
+  });
+
+  it("3:15pm Toronto is the midpoint of the 3:00pm slot (position 6.5)", () => {
+    // 19:15 UTC = 3:15 PM EDT
+    expect(getNowLinePosition(new Date("2026-08-29T19:15:00Z"))).toBe(6.5);
+  });
+
+  it("6:30pm Toronto is the final boundary (position 13), not null", () => {
+    // 22:30 UTC = 6:30 PM EDT
+    expect(getNowLinePosition(new Date("2026-08-29T22:30:00Z"))).toBe(13);
+  });
+});
+
+describe("scheduleNow - timezone math is independent of the host machine's TZ", () => {
+  const originalTz = process.env.TZ;
+
+  afterEach(() => {
+    process.env.TZ = originalTz;
+  });
+
+  it("returns the same position regardless of process.env.TZ", () => {
+    const instant = new Date("2026-08-29T19:15:00Z");
+
+    process.env.TZ = "Asia/Tokyo";
+    const tokyoResult = getNowLinePosition(instant);
+
+    process.env.TZ = "America/Los_Angeles";
+    const laResult = getNowLinePosition(instant);
+
+    process.env.TZ = "UTC";
+    const utcResult = getNowLinePosition(instant);
+
+    expect(tokyoResult).toBe(6.5);
+    expect(laResult).toBe(6.5);
+    expect(utcResult).toBe(6.5);
+  });
+});

--- a/src/lib/scheduleNow.ts
+++ b/src/lib/scheduleNow.ts
@@ -1,0 +1,69 @@
+import {
+  EVENT_START_MINUTES,
+  EVENT_END_MINUTES,
+  SLOT_MINUTES,
+} from "./torontoSchedule";
+
+const EVENT_TIMEZONE = "America/Toronto";
+const EVENT_YEAR = 2026;
+const EVENT_MONTH = 8; // August
+const EVENT_DAY = 29;
+
+interface TorontoParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+function getTorontoParts(date: Date): TorontoParts {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: EVENT_TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const parts: Record<string, string> = {};
+  for (const part of formatter.formatToParts(date)) {
+    parts[part.type] = part.value;
+  }
+
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    // hour12: false can format midnight as "24" in some ICU versions.
+    hour: Number(parts.hour) % 24,
+    minute: Number(parts.minute),
+  };
+}
+
+/**
+ * Fractional slot position (0 = 12:00pm, 13 = 6:30pm) for the desktop grid's
+ * "now" line, computed in America/Toronto regardless of the host machine's
+ * timezone. Returns null on any date other than Aug 29, 2026, or outside
+ * event hours.
+ */
+export function getNowLinePosition(date: Date): number | null {
+  const { year, month, day, hour, minute } = getTorontoParts(date);
+
+  if (year !== EVENT_YEAR || month !== EVENT_MONTH || day !== EVENT_DAY) {
+    return null;
+  }
+
+  const minutesSinceMidnight = hour * 60 + minute;
+
+  if (
+    minutesSinceMidnight < EVENT_START_MINUTES ||
+    minutesSinceMidnight > EVENT_END_MINUTES
+  ) {
+    return null;
+  }
+
+  return (minutesSinceMidnight - EVENT_START_MINUTES) / SLOT_MINUTES;
+}

--- a/src/lib/torontoSchedule.test.ts
+++ b/src/lib/torontoSchedule.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import {
+  venues,
+  slots,
+  sessions,
+  fullWidthRows,
+  venueKeyText,
+} from "./torontoSchedule";
+
+describe("torontoSchedule - venues", () => {
+  it("lists exactly the 6 Figma venue columns in order", () => {
+    expect(venues.map((v) => v.id)).toEqual([
+      "hackathon",
+      "showcase",
+      "community",
+      "main",
+      "aws",
+      "workshops",
+    ]);
+    expect(venues.map((v) => v.label)).toEqual([
+      "Basement · Hackathon",
+      "L2 · Showcase",
+      "L3 · Community Stage",
+      "L4 · Main Stage",
+      "L5 · AWS Stage",
+      "Workshops",
+    ]);
+  });
+});
+
+describe("torontoSchedule - slots", () => {
+  it("runs 12:00pm to 6:30pm in 30-minute steps (14 markers)", () => {
+    expect(slots).toHaveLength(14);
+    expect(slots[0]).toBe("12:00 PM");
+    expect(slots[slots.length - 1]).toBe("6:30 PM");
+  });
+});
+
+describe("torontoSchedule - doors open", () => {
+  it("Doors Open at 12:00pm on Community, Main, and AWS only", () => {
+    const doorsOpen = sessions.filter((s) => s.title === "Doors Open");
+    expect(doorsOpen.map((s) => s.venue).sort()).toEqual([
+      "aws",
+      "community",
+      "main",
+    ]);
+    doorsOpen.forEach((s) => {
+      expect(s.start).toBe("12:00 PM");
+      expect(s.slots).toBe(1);
+    });
+  });
+});
+
+describe("torontoSchedule - keynotes", () => {
+  it("Main Stage Keynote is at 1:00pm", () => {
+    const keynote = sessions.find(
+      (s) => s.venue === "main" && s.kind === "keynote",
+    );
+    expect(keynote?.title).toBe("Keynote");
+    expect(keynote?.start).toBe("1:00 PM");
+  });
+
+  it("AWS Keynote is at 1:30pm", () => {
+    const awsKeynote = sessions.find(
+      (s) => s.venue === "aws" && s.kind === "keynote",
+    );
+    expect(awsKeynote?.title).toBe("AWS Keynote");
+    expect(awsKeynote?.start).toBe("1:30 PM");
+  });
+});
+
+describe("torontoSchedule - Main Stage panel", () => {
+  it("spans 2:00pm-3:00pm (60 minutes, 2 slots)", () => {
+    const panel = sessions.find((s) => s.kind === "panel");
+    expect(panel?.title).toBe("Panel: AI Agents, can we trust them?");
+    expect(panel?.venue).toBe("main");
+    expect(panel?.start).toBe("2:00 PM");
+    expect(panel?.end).toBe("3:00 PM");
+    expect(panel?.slots).toBe(2);
+  });
+});
+
+describe("torontoSchedule - hackathon", () => {
+  it("Round 1 is at 2:00pm and Round 2 (Elimination) is at 3:30pm, both live on the Basement stage", () => {
+    const rounds = sessions
+      .filter((s) => s.kind === "hackathon-round")
+      .sort((a, b) => a.startMinutes - b.startMinutes);
+    expect(rounds.map((r) => r.title)).toEqual([
+      "Hackathon Round 1 Live on Stage",
+      "Hackathon Round 2 Elimination Live on Stage",
+    ]);
+    expect(rounds.map((r) => r.start)).toEqual(["2:00 PM", "3:30 PM"]);
+    rounds.forEach((r) => {
+      expect(r.venue).toBe("hackathon");
+      expect(r.badges).toContain("LIVE");
+    });
+  });
+
+  it("the Final happens live on the Main Stage at 5:00pm, not on the Basement venue", () => {
+    const final = sessions.find((s) => s.kind === "hackathon-final");
+    expect(final?.venue).toBe("main");
+    expect(final?.title).toBe("Hackathon Final Live on Main Stage");
+    expect(final?.start).toBe("5:00 PM");
+    expect(final?.badges).toContain("LIVE FINAL");
+  });
+});
+
+describe("torontoSchedule - workshops", () => {
+  it("Cloud Workshop Level 2 runs 2:30pm-3:30pm (60 minutes)", () => {
+    const w2 = sessions.find((s) => s.title === "Cloud Workshop Level 2");
+    expect(w2?.venue).toBe("workshops");
+    expect(w2?.start).toBe("2:30 PM");
+    expect(w2?.end).toBe("3:30 PM");
+  });
+
+  it("Cloud Workshop Level 3 runs 3:30pm-5:00pm (90 minutes)", () => {
+    const w3 = sessions.find((s) => s.title === "Cloud Workshop Level 3");
+    expect(w3?.venue).toBe("workshops");
+    expect(w3?.start).toBe("3:30 PM");
+    expect(w3?.end).toBe("5:00 PM");
+  });
+});
+
+describe("torontoSchedule - after party", () => {
+  it("is a Main Stage-only session at 6:30pm, not a full-width row", () => {
+    const afterParty = sessions.find((s) => s.kind === "after-party");
+    expect(afterParty?.venue).toBe("main");
+    expect(afterParty?.start).toBe("6:30 PM");
+    expect(afterParty?.title).toBe(
+      "After-party starts at a nearby location (5min walk from event)",
+    );
+    expect(fullWidthRows.find((r) => r.title === "After Party")).toBeUndefined();
+  });
+});
+
+describe("torontoSchedule - full-width rows", () => {
+  it("Hot Food Break at 3:00pm spans every venue except Workshops", () => {
+    const foodBreak = fullWidthRows.find((r) => r.title === "Hot Food Break");
+    expect(foodBreak?.start).toBe("3:00 PM");
+    expect(foodBreak?.end).toBe("3:30 PM");
+    expect(foodBreak?.venues).toEqual([
+      "hackathon",
+      "showcase",
+      "community",
+      "main",
+      "aws",
+    ]);
+  });
+
+  it("Event Conclusion at 6:00pm spans all 6 venues", () => {
+    const conclusion = fullWidthRows.find(
+      (r) => r.title === "Event Conclusion",
+    );
+    expect(conclusion?.start).toBe("6:00 PM");
+    expect(conclusion?.end).toBe("6:30 PM");
+    expect(conclusion?.venues).toEqual([
+      "hackathon",
+      "showcase",
+      "community",
+      "main",
+      "aws",
+      "workshops",
+    ]);
+  });
+
+  it("has exactly 2 full-width rows", () => {
+    expect(fullWidthRows).toHaveLength(2);
+  });
+});
+
+describe("torontoSchedule - overflow live streams", () => {
+  it("simulcasts the Main Stage on Basement, Community, and AWS during the opening remarks/keynote", () => {
+    const streams = sessions.filter(
+      (s) => s.kind === "stream" && s.start === "12:30 PM",
+    );
+    expect(streams.map((s) => s.venue).sort()).toEqual([
+      "aws",
+      "community",
+      "hackathon",
+    ]);
+    streams.forEach((s) => {
+      expect(s.end).toBe("1:30 PM");
+      expect(s.badges).toContain("LIVE");
+    });
+  });
+});
+
+describe("torontoSchedule - venue key", () => {
+  it("exports the exact venue-key line text", () => {
+    expect(venueKeyText).toBe(
+      "3 stages + workshops across 5 levels + basement hackathon",
+    );
+  });
+});

--- a/src/lib/torontoSchedule.ts
+++ b/src/lib/torontoSchedule.ts
@@ -1,0 +1,614 @@
+// Cloud Summit Toronto — Aug 29, 2026 — Full Event Schedule (Issue #176)
+// Transcribed from the official event-schedule table provided by Matt.
+// Two cells were fragmentary in the source table ("AWS Jam on Level 5 Starts"
+// at 2:00pm followed by "Cloud" at 2:30pm and "Workshop Level 2" at 3:00pm);
+// they're reconstructed here as "Cloud Workshop Level 2" spanning 2:30-3:30pm,
+// matching the same "<title>" + "(cont.)" pattern used for Cloud Workshop
+// Level 3. Flag to Matt if that reconstruction is wrong.
+
+export type VenueId =
+  | "hackathon"
+  | "showcase"
+  | "community"
+  | "main"
+  | "aws"
+  | "workshops";
+
+export type Track = VenueId | "food";
+
+export type SessionKind =
+  | "doors-open"
+  | "welcome"
+  | "keynote"
+  | "talk"
+  | "panel"
+  | "stream"
+  | "break"
+  | "showcase"
+  | "hackathon-round"
+  | "hackathon-transition"
+  | "hackathon-final"
+  | "wrap-up"
+  | "after-party"
+  | "workshop"
+  | "workshop-note";
+
+export interface Venue {
+  id: VenueId;
+  label: string;
+}
+
+export interface Session {
+  id: string;
+  venue: VenueId;
+  track: Track;
+  kind: SessionKind;
+  title: string;
+  start: string;
+  end: string;
+  startMinutes: number;
+  endMinutes: number;
+  slots: number;
+  badges: string[];
+}
+
+export interface FullWidthRow {
+  id: string;
+  title: string;
+  start: string;
+  end: string;
+  startMinutes: number;
+  endMinutes: number;
+  /** Venues (in grid-column order) this banner row visually covers. */
+  venues: VenueId[];
+}
+
+export interface LegendEntry {
+  track: Track;
+  label: string;
+  color: string;
+  fallback: string;
+}
+
+const SLOT_MINUTES = 30;
+const EVENT_START_MINUTES = 12 * 60; // 12:00 PM
+const EVENT_END_MINUTES = 18 * 60 + 30; // 6:30 PM
+
+export { EVENT_START_MINUTES, EVENT_END_MINUTES, SLOT_MINUTES };
+
+/** Formats minutes-since-midnight as "12:00 PM" / "6:30 PM" etc. */
+function formatMinutes(totalMinutes: number): string {
+  const hour24 = Math.floor(totalMinutes / 60) % 24;
+  const minute = totalMinutes % 60;
+  const period = hour24 >= 12 ? "PM" : "AM";
+  const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+  const minuteStr = minute === 0 ? "00" : String(minute).padStart(2, "0");
+  return `${hour12}:${minuteStr} ${period}`;
+}
+
+export const slots: string[] = (() => {
+  const out: string[] = [];
+  for (
+    let m = EVENT_START_MINUTES;
+    m <= EVENT_END_MINUTES;
+    m += SLOT_MINUTES
+  ) {
+    out.push(formatMinutes(m));
+  }
+  return out;
+})();
+
+export const venues: Venue[] = [
+  { id: "hackathon", label: "Basement · Hackathon" },
+  { id: "showcase", label: "L2 · Showcase" },
+  { id: "community", label: "L3 · Community Stage" },
+  { id: "main", label: "L4 · Main Stage" },
+  { id: "aws", label: "L5 · AWS Stage" },
+  { id: "workshops", label: "Workshops" },
+];
+
+interface SessionInput {
+  id: string;
+  venue: VenueId;
+  track: Track;
+  kind: SessionKind;
+  title: string;
+  startMinutes: number;
+  durationMinutes: number;
+  badges?: string[];
+}
+
+function buildSession(input: SessionInput): Session {
+  const endMinutes = input.startMinutes + input.durationMinutes;
+  return {
+    id: input.id,
+    venue: input.venue,
+    track: input.track,
+    kind: input.kind,
+    title: input.title,
+    start: formatMinutes(input.startMinutes),
+    end: formatMinutes(endMinutes),
+    startMinutes: input.startMinutes,
+    endMinutes,
+    slots: input.durationMinutes / SLOT_MINUTES,
+    badges: input.badges ?? [],
+  };
+}
+
+const rawSessions: SessionInput[] = [
+  // Basement · Hackathon
+  {
+    id: "hackathon-1",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "break",
+    title: "Drinks & Snacks",
+    startMinutes: 12 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "hackathon-2",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "stream",
+    title: "Overflow live stream of Main Stage",
+    startMinutes: 12 * 60 + 30,
+    durationMinutes: 60,
+    badges: ["LIVE"],
+  },
+  {
+    id: "hackathon-3",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "break",
+    title: "Drinks & Snacks",
+    startMinutes: 13 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "hackathon-4",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "hackathon-round",
+    title: "Hackathon Round 1 Live on Stage",
+    startMinutes: 14 * 60,
+    durationMinutes: 30,
+    badges: ["LIVE"],
+  },
+  {
+    id: "hackathon-5",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "break",
+    title: "Drinks & Snacks",
+    startMinutes: 14 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "hackathon-6",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "hackathon-round",
+    title: "Hackathon Round 2 Elimination Live on Stage",
+    startMinutes: 15 * 60 + 30,
+    durationMinutes: 30,
+    badges: ["LIVE"],
+  },
+  {
+    id: "hackathon-7",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "break",
+    title: "Drinks & Snacks",
+    startMinutes: 16 * 60,
+    durationMinutes: 60,
+  },
+  {
+    id: "hackathon-8",
+    venue: "hackathon",
+    track: "hackathon",
+    kind: "hackathon-transition",
+    title: "Hackathon moves to Level 4 Main Stage",
+    startMinutes: 17 * 60,
+    durationMinutes: 30,
+  },
+
+  // L2 · Showcase
+  {
+    id: "showcase-1",
+    venue: "showcase",
+    track: "showcase",
+    kind: "showcase",
+    title: "Showcase Space Opens",
+    startMinutes: 13 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "showcase-2",
+    venue: "showcase",
+    track: "showcase",
+    kind: "showcase",
+    title: "Showcase",
+    startMinutes: 14 * 60,
+    durationMinutes: 60,
+  },
+  {
+    id: "showcase-3",
+    venue: "showcase",
+    track: "showcase",
+    kind: "showcase",
+    title: "Showcase",
+    startMinutes: 15 * 60 + 30,
+    durationMinutes: 120,
+  },
+
+  // L3 · Community Stage
+  {
+    id: "community-1",
+    venue: "community",
+    track: "community",
+    kind: "doors-open",
+    title: "Doors Open",
+    startMinutes: 12 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "community-2",
+    venue: "community",
+    track: "community",
+    kind: "stream",
+    title: "Overflow live stream of Main Stage",
+    startMinutes: 12 * 60 + 30,
+    durationMinutes: 60,
+    badges: ["LIVE"],
+  },
+  {
+    id: "community-3",
+    venue: "community",
+    track: "community",
+    kind: "talk",
+    title: "Community Stage Talk",
+    startMinutes: 13 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "community-4",
+    venue: "community",
+    track: "community",
+    kind: "talk",
+    title: "Community Stage Talk",
+    startMinutes: 14 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "community-5",
+    venue: "community",
+    track: "community",
+    kind: "talk",
+    title: "Community Stage Talk",
+    startMinutes: 14 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "community-6",
+    venue: "community",
+    track: "community",
+    kind: "talk",
+    title: "Community Stage Talk",
+    startMinutes: 15 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "community-7",
+    venue: "community",
+    track: "community",
+    kind: "talk",
+    title: "Community Stage Talk",
+    startMinutes: 16 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "community-8",
+    venue: "community",
+    track: "community",
+    kind: "talk",
+    title: "Community Stage Talk",
+    startMinutes: 16 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "community-9",
+    venue: "community",
+    track: "community",
+    kind: "stream",
+    title: "Overflow live stream of Main Stage",
+    startMinutes: 17 * 60,
+    durationMinutes: 60,
+    badges: ["LIVE"],
+  },
+
+  // L4 · Main Stage
+  {
+    id: "main-1",
+    venue: "main",
+    track: "main",
+    kind: "doors-open",
+    title: "Doors Open",
+    startMinutes: 12 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "main-2",
+    venue: "main",
+    track: "main",
+    kind: "welcome",
+    title: "Main Stage: Welcome Remarks",
+    startMinutes: 12 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "main-3",
+    venue: "main",
+    track: "main",
+    kind: "keynote",
+    title: "Keynote",
+    startMinutes: 13 * 60,
+    durationMinutes: 30,
+    badges: ["KEYNOTE"],
+  },
+  {
+    id: "main-4",
+    venue: "main",
+    track: "main",
+    kind: "talk",
+    title: "Main Stage Talk",
+    startMinutes: 13 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "main-5",
+    venue: "main",
+    track: "main",
+    kind: "panel",
+    title: "Panel: AI Agents, can we trust them?",
+    startMinutes: 14 * 60,
+    durationMinutes: 60,
+    badges: ["PANEL · 60 MIN"],
+  },
+  {
+    id: "main-6",
+    venue: "main",
+    track: "main",
+    kind: "talk",
+    title: "Main Stage Talk",
+    startMinutes: 15 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "main-7",
+    venue: "main",
+    track: "main",
+    kind: "talk",
+    title: "Main Stage Talk",
+    startMinutes: 16 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "main-8",
+    venue: "main",
+    track: "main",
+    kind: "talk",
+    title: "Main Stage Talk",
+    startMinutes: 16 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "main-9",
+    venue: "main",
+    track: "main",
+    kind: "hackathon-final",
+    title: "Hackathon Final Live on Main Stage",
+    startMinutes: 17 * 60,
+    durationMinutes: 30,
+    badges: ["LIVE FINAL"],
+  },
+  {
+    id: "main-10",
+    venue: "main",
+    track: "main",
+    kind: "wrap-up",
+    title: "Event Wrap-Up on Main Stage",
+    startMinutes: 17 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "main-11",
+    venue: "main",
+    track: "main",
+    kind: "after-party",
+    title: "After-party starts at a nearby location (5min walk from event)",
+    startMinutes: 18 * 60 + 30,
+    durationMinutes: 30,
+  },
+
+  // L5 · AWS Stage
+  {
+    id: "aws-1",
+    venue: "aws",
+    track: "aws",
+    kind: "doors-open",
+    title: "Doors Open",
+    startMinutes: 12 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "aws-2",
+    venue: "aws",
+    track: "aws",
+    kind: "stream",
+    title: "Overflow live stream of Main Stage",
+    startMinutes: 12 * 60 + 30,
+    durationMinutes: 60,
+    badges: ["LIVE"],
+  },
+  {
+    id: "aws-3",
+    venue: "aws",
+    track: "aws",
+    kind: "keynote",
+    title: "AWS Keynote",
+    startMinutes: 13 * 60 + 30,
+    durationMinutes: 30,
+    badges: ["KEYNOTE"],
+  },
+  {
+    id: "aws-4",
+    venue: "aws",
+    track: "aws",
+    kind: "talk",
+    title: "AWS Stage Talk",
+    startMinutes: 14 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "aws-5",
+    venue: "aws",
+    track: "aws",
+    kind: "talk",
+    title: "AWS Stage Talk",
+    startMinutes: 14 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "aws-6",
+    venue: "aws",
+    track: "aws",
+    kind: "talk",
+    title: "AWS Stage Talk",
+    startMinutes: 15 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "aws-7",
+    venue: "aws",
+    track: "aws",
+    kind: "talk",
+    title: "AWS Stage Talk",
+    startMinutes: 16 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "aws-8",
+    venue: "aws",
+    track: "aws",
+    kind: "talk",
+    title: "AWS Stage Talk",
+    startMinutes: 16 * 60 + 30,
+    durationMinutes: 30,
+  },
+  {
+    id: "aws-9",
+    venue: "aws",
+    track: "aws",
+    kind: "stream",
+    title: "Overflow live stream of Main Stage",
+    startMinutes: 17 * 60,
+    durationMinutes: 60,
+    badges: ["LIVE"],
+  },
+
+  // Workshops lane
+  {
+    id: "workshops-1",
+    venue: "workshops",
+    track: "workshops",
+    kind: "workshop-note",
+    title: "AWS Jam on Level 5 Starts",
+    startMinutes: 14 * 60,
+    durationMinutes: 30,
+  },
+  {
+    id: "workshops-2",
+    venue: "workshops",
+    track: "workshops",
+    kind: "workshop",
+    title: "Cloud Workshop Level 2",
+    startMinutes: 14 * 60 + 30,
+    durationMinutes: 60,
+  },
+  {
+    id: "workshops-3",
+    venue: "workshops",
+    track: "workshops",
+    kind: "workshop",
+    title: "Cloud Workshop Level 3",
+    startMinutes: 15 * 60 + 30,
+    durationMinutes: 90,
+  },
+];
+
+export const sessions: Session[] = rawSessions.map(buildSession);
+
+interface FullWidthRowInput {
+  id: string;
+  title: string;
+  startMinutes: number;
+  durationMinutes: number;
+  venues: VenueId[];
+}
+
+const rawFullWidthRows: FullWidthRowInput[] = [
+  {
+    id: "food-break",
+    title: "Hot Food Break",
+    startMinutes: 15 * 60,
+    durationMinutes: 30,
+    // Workshops doesn't pause for the food break — Cloud Workshop Level 2
+    // runs straight through this slot.
+    venues: ["hackathon", "showcase", "community", "main", "aws"],
+  },
+  {
+    id: "event-conclusion",
+    title: "Event Conclusion",
+    startMinutes: 18 * 60,
+    durationMinutes: 30,
+    venues: ["hackathon", "showcase", "community", "main", "aws", "workshops"],
+  },
+];
+
+export const fullWidthRows: FullWidthRow[] = rawFullWidthRows.map((row) => {
+  const endMinutes = row.startMinutes + row.durationMinutes;
+  return {
+    id: row.id,
+    title: row.title,
+    start: formatMinutes(row.startMinutes),
+    end: formatMinutes(endMinutes),
+    startMinutes: row.startMinutes,
+    endMinutes,
+    venues: row.venues,
+  };
+});
+
+export const legend: LegendEntry[] = [
+  { track: "main", label: "Main", color: "oklch(0.75 0.11 255)", fallback: "#5B8DEF" },
+  { track: "community", label: "Community", color: "oklch(0.75 0.11 185)", fallback: "#3DC9B0" },
+  { track: "aws", label: "AWS", color: "oklch(0.78 0.11 65)", fallback: "#E8A33D" },
+  { track: "hackathon", label: "Hackathon", color: "oklch(0.76 0.12 310)", fallback: "#C86ADB" },
+  { track: "workshops", label: "Workshops", color: "oklch(0.75 0.11 150)", fallback: "#4FC97A" },
+  { track: "food", label: "Food", color: "oklch(0.8 0.1 95)", fallback: "#E0C24F" },
+];
+
+export const filterTracks: { id: VenueId | "all"; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "main", label: "Main Stage" },
+  { id: "community", label: "Community" },
+  { id: "aws", label: "AWS" },
+  { id: "hackathon", label: "Hackathon" },
+  { id: "workshops", label: "Workshops" },
+  { id: "showcase", label: "Showcase" },
+];
+
+export const venueKeyText =
+  "3 stages + workshops across 5 levels + basement hackathon";
+
+export const dateLine = "Saturday, August 29th, 2026 · 12:00 PM – 6:30 PM";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -157,12 +157,12 @@ const ogImageUrl = absoluteUrl(DEFAULT_OG_IMAGE_PATH, Astro);
     <Navigation content={navigationContent} />
     <Hero content={content} />
     <CallToActions />
+    <Schedule />
 
     <WhatIsCloudSummit content={whatIsCloudSummitContent} />
     <CloudSummitActivities content={cloudSummitActivitiesContent} />
     <AboutCPCA content={aboutCPCAContent} />
     <EventLocations />
-    <Schedule />
     <Speaker content={homepageSpeakers} />
      <EventMap content={eventMapContent} />
     <SummitSummary content={eventHighlightsContent} />


### PR DESCRIPTION
## Summary
Merges staging into main, bringing in four features/fixes:

- **Toronto schedule** — publishes the first version of the event schedule (desktop grid, mobile timeline, and a "now" indicator line), backed by new `torontoSchedule.ts` and `scheduleFilter.ts`/`scheduleNow.ts` helpers. `<Schedule />` is also reordered on the homepage to render earlier, right after the CTAs. (#176)
- **Newsletter links open in a new tab** — the newsletter CTA and footer "Subscribe to Newsletter" link now use `target="_blank" rel="noopener noreferrer"` instead of navigating away from the site. (#138)
- **Footer website credits updated for Toronto** — added a new `websiteCredits` entry for Ahmad and Vincent, preserving the original Vancouver credits under `websiteCredits2026_Vancouver`. (#142)
- **Footer LinkedIn link fixed** — footer LinkedIn now points to the same destination used on awsday.ca. (#140)